### PR TITLE
Update color-picker to not use text-field and correct styling inconsistencies

### DIFF
--- a/change/design-to-code-3ffd788c-8b25-472e-9b74-9888bc30228f.json
+++ b/change/design-to-code-3ffd788c-8b25-472e-9b74-9888bc30228f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "This package has not yet been published",
+  "packageName": "design-to-code",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/design-to-code/app/examples/color-picker/index.html
+++ b/packages/design-to-code/app/examples/color-picker/index.html
@@ -11,18 +11,27 @@
                 width: 100%;
                 height: 100%;
                 font-family: Arial, Helvetica, sans-serif;
-                background-color: var(--fill-color);
+                background-color: var(--dtc-l4-color);
                 padding: 20px;
                 color: white;
             }
         </style>
+        <link
+            rel="stylesheet"
+            href="<%= htmlWebpackPlugin.options.globalCssVariableStylesheet %>"
+        />
     </head>
     <body>
         <div id="root">
-            <dtc-color-picker id="color_picker"></dtc-color-picker>
+            <dtc-color-picker
+                id="color_picker"
+                control-text-field-stylesheet="<%= htmlWebpackPlugin.options.controlTextFieldStylesheet %>"
+                common-input-stylesheet="<%= htmlWebpackPlugin.options.commonInputStylesheet %>"
+                common-default-font-stylesheet="<%= htmlWebpackPlugin.options.commonDefaultFontStylesheet %>"
+            ></dtc-color-picker>
             <br />
             Output:
-            <input id="outputValue" type="text" style="width: 800px;" />
+            <input id="outputValue" type="text" style="width: 800px" />
         </div>
         <script>
             const colorPickerElement = document.getElementById("color_picker");

--- a/packages/design-to-code/app/examples/color-picker/index.ts
+++ b/packages/design-to-code/app/examples/color-picker/index.ts
@@ -1,8 +1,4 @@
 import { provideFASTDesignSystem } from "@microsoft/fast-components";
-import { fastTextField } from "@microsoft/fast-components";
 import { colorPickerComponent } from "../../../src/web-components/color-picker/index.js";
 
-provideFASTDesignSystem()
-    .withPrefix("dtc")
-    .register(fastTextField())
-    .register(colorPickerComponent());
+provideFASTDesignSystem().withPrefix("dtc").register(colorPickerComponent());

--- a/packages/design-to-code/app/examples/color-picker/webpack.common.cjs
+++ b/packages/design-to-code/app/examples/color-picker/webpack.common.cjs
@@ -62,6 +62,10 @@ module.exports = {
             title: "Test application",
             inject: "body",
             template: path.resolve(appDir, "index.html"),
+            globalCssVariableStylesheet: "/global.css-variables.css",
+            controlTextFieldStylesheet: "/control.text-field.css",
+            commonInputStylesheet: "/common.input.css",
+            commonDefaultFontStylesheet: "/common.default-font.css",
         }),
     ],
 };

--- a/packages/design-to-code/app/examples/file/index.html
+++ b/packages/design-to-code/app/examples/file/index.html
@@ -11,11 +11,15 @@
                 width: 100%;
                 height: 100%;
                 font-family: Arial, Helvetica, sans-serif;
-                background-color: var(--fill-color);
+                background-color: var(--dtc-l4-color);
                 padding: 20px;
                 color: white;
             }
         </style>
+        <link
+            rel="stylesheet"
+            href="<%= htmlWebpackPlugin.options.globalCssVariableStylesheet %>"
+        />
     </head>
     <body>
         <div id="root">

--- a/packages/design-to-code/app/examples/file/index.ts
+++ b/packages/design-to-code/app/examples/file/index.ts
@@ -1,10 +1,6 @@
 import { provideFASTDesignSystem } from "@microsoft/fast-components";
 import { fileComponent } from "../../../src/web-components/file/index.js";
 import { fileActionObjectUrlComponent } from "../../../src/web-components/file-action-objecturl/index.js";
-import cssVariables from "../../../src/web-components/style/global.css-variables.css";
-
-// tree-shaking
-cssVariables;
 
 provideFASTDesignSystem()
     .withPrefix("dtc")

--- a/packages/design-to-code/app/examples/file/webpack.common.cjs
+++ b/packages/design-to-code/app/examples/file/webpack.common.cjs
@@ -62,6 +62,7 @@ module.exports = {
             title: "Test application",
             inject: "body",
             template: path.resolve(appDir, "index.html"),
+            globalCssVariableStylesheet: "/global.css-variables.css",
             controlButtonStylesheet: "/control.button.css",
             commonInputStylesheet: "/common.input.css",
             commonDefaultFontStylesheet: "/common.default-font.css",

--- a/packages/design-to-code/src/web-components/color-picker/color-picker.spec.ts
+++ b/packages/design-to-code/src/web-components/color-picker/color-picker.spec.ts
@@ -1,12 +1,9 @@
 import { expect } from "chai";
-import { fastTextField } from "@microsoft/fast-components";
 import { DesignSystem } from "@microsoft/fast-foundation";
 import { fixture } from "../../__test__/fixture";
 import { ColorPicker } from "./color-picker";
 import { colorPickerComponent } from ".";
 import { html } from "@microsoft/fast-element";
-
-DesignSystem.getOrCreate().register(fastTextField());
 
 async function setup() {
     const { element, connect, disconnect } = await fixture<ColorPicker>(

--- a/packages/design-to-code/src/web-components/color-picker/color-picker.styles.ts
+++ b/packages/design-to-code/src/web-components/color-picker/color-picker.styles.ts
@@ -8,30 +8,26 @@ export const colorPickerStyles: (
     context: ElementDefinitionContext,
     definition: FoundationElementDefinition
 ) => ElementStyles = () => css`
-    .popup,
-    .popup__open {
+    .popup {
         display: none;
-        padding: 2px;
-        flex-direction: row;
-        background-color: var(--neutral-layer-floating);
-        border: calc(var(--outline-width) * 1px) solid var(--neutral-outline-rest);
-        border-radius: calc(var(--corner-radius) * 1px);
-    }
-
-    .popup__open {
-        display: flex;
         position: absolute;
         z-index: 1;
-        margin-left: -32px;
+        padding: 8px;
+        flex-direction: row;
+        background-color: var(--dtc-l3-color);
+        border-radius: var(--dtc-border-radius);
+    }
+
+    .popup.popup__open {
+        display: flex;
     }
 
     .pickers {
-        margin: 4px 6px 4px 4px;
+        margin-right: 4px;
     }
 
     .inputs {
         width: 65px;
-        margin: 0 4px 4px 0;
     }
 
     .pickers-saturation {
@@ -110,28 +106,14 @@ export const colorPickerStyles: (
     .control-color {
         position: relative;
         display: inline-block;
-        width: 25px;
-        height: 25px;
+        width: 24px;
+        height: 24px;
         margin-top: auto;
         margin-bottom: auto;
-        border: 1px solid var(--dtc-l1-color, #333333);
+        border-radius: var(--dtc-border-radius) 0 0 var(--dtc-border-radius);
     }
 
-    .control-color::before {
-        position: absolute;
-        content: "";
-        left: 0;
-        right: 0;
-        top: 0;
-        bottom: 0;
-        background-image: linear-gradient(
-            to bottom left,
-            transparent calc(50% - 1px),
-            var(--dtc-l1-color, #333333),
-            transparent calc(50% + 1px)
-        );
-    }
-
+    .control-color::before,
     .control-color::after {
         position: absolute;
         content: "";
@@ -139,6 +121,38 @@ export const colorPickerStyles: (
         right: 0;
         top: 0;
         bottom: 0;
+        border-radius: var(--dtc-border-radius) 0 0 var(--dtc-border-radius);
+    }
+
+    .control-color::before {
+        border: 1px solid var(--dtc-l1-color);
+        background-image: linear-gradient(
+            to bottom left,
+            transparent calc(50% - 1px),
+            var(--dtc-l1-color),
+            transparent calc(50% + 1px)
+        );
+    }
+
+    .control-color::after {
+        border: 1px solid var(--selected-color-value);
         background-color: var(--selected-color-value);
+    }
+
+    .content .dtc-text-field-control input {
+        border-radius: 0 var(--dtc-border-radius) var(--dtc-border-radius) 0;
+    }
+
+    .popup .dtc-text-field-control {
+        justify-content: space-between;
+        margin-bottom: 4px;
+    }
+
+    .popup .dtc-text-field-control input {
+        width: unset;
+    }
+
+    .popup .dtc-text-field-control span {
+        padding-left: 4px;
     }
 `;

--- a/packages/design-to-code/src/web-components/color-picker/color-picker.template.ts
+++ b/packages/design-to-code/src/web-components/color-picker/color-picker.template.ts
@@ -1,7 +1,7 @@
 import { html, ref, ViewTemplate } from "@microsoft/fast-element";
 import { ElementDefinitionContext } from "@microsoft/fast-foundation";
-import { TextField } from "@microsoft/fast-components";
 import { ColorPicker } from "./color-picker.js";
+import dtcClassName from "../style/class-names.js";
 
 /**
  * The template for the color picker component.
@@ -18,26 +18,41 @@ export const colorPickerTemplate: (
                 x.mouseActive ? x.handleMouseMove(c.event as MouseEvent) : null}"
             @mouseup="${(x, c) =>
                 x.mouseActive ? x.handleMouseUp(c.event as MouseEvent) : null}"
-            style="--selected-color-value: ${x => (x.value ? x.value : "transparent")}"
         >
-            <div class="root" part="root">
-                <${context.tagFor(TextField)}
-                    class="root-control"
-                    part="control"
-                    id="control"
-                    @input="${x => x.handleTextInput()}"
-                    @change="${x => x.handleChange()}"
-                    ?autofocus="${x => x.autofocus}"
-                    ?disabled="${x => x.disabled}"
-                    placeholder="${x => x.placeholder}"
-                    ?readonly="${x => x.readOnly}"
-                    ?required="${x => x.required}"
-                    :value="${x => x.value}"
-                    ${ref("control")}
-                >
-                    <div slot="start" class="control-color"></div>
-                </${context.tagFor(TextField)}>
-                <div class="${x => (x.open ? "popup__open" : "popup")}">
+            <div
+                class="root"
+                part="root"
+                style="--selected-color-value: ${x =>
+                    x.value ? x.value : "transparent"}"
+            >
+                <link rel="stylesheet" href="${x => x.commonDefaultFontStylesheet}" />
+                <link rel="stylesheet" href="${x => x.commonInputStylesheet}" />
+                <link rel="stylesheet" href="${x => x.controlTextFieldStylesheet}" />
+                <div class="content">
+                    <div
+                        class="${x =>
+                            x.disabled
+                                ? `${dtcClassName.textFieldControl} ${dtcClassName.textFieldControl__disabled}`
+                                : dtcClassName.textFieldControl}"
+                    >
+                        <div class="control-color"></div>
+                        <input
+                            class="root-control ${dtcClassName.commonDefaultFont} ${dtcClassName.commonInput}"
+                            part="control"
+                            id="control"
+                            @input="${x => x.handleTextInput()}"
+                            @change="${x => x.handleChange()}"
+                            ?autofocus="${x => x.autofocus}"
+                            ?disabled="${x => x.disabled}"
+                            placeholder="${x => x.placeholder}"
+                            ?readonly="${x => x.readOnly}"
+                            ?required="${x => x.required}"
+                            :value="${x => x.value}"
+                            ${ref("control")}
+                        />
+                    </div>
+                </div>
+                <div class="${x => (x.open ? "popup popup__open" : "popup")}">
                     <div class="pickers">
                         <div
                             class="pickers-saturation"
@@ -49,7 +64,7 @@ export const colorPickerTemplate: (
                                 class="saturation-indicator"
                                 style="left: ${x =>
                                     x.uiValues.SatValLeftPos - 2}%; top: ${x =>
-        x.uiValues.SatValTopPos - 2}%"
+                                    x.uiValues.SatValTopPos - 2}%"
                             ></div>
                         </div>
                         <div
@@ -79,63 +94,76 @@ export const colorPickerTemplate: (
                         </div>
                     </div>
                     <div class="inputs">
-                        <${context.tagFor(TextField)}
-                            maxlength="3"
-                            size="3"
-                            @input="${(x, c) => x.handleTextValueInput("r", c.event)}"
-                            :value="${x => Math.round(x.uiValues.RGBColor.r * 255)}"
-                        >
-                            <span slot="start">R:</span>
-                        </${context.tagFor(TextField)}>
-                        <${context.tagFor(TextField)}
-                            maxlength="3"
-                            size="3"
-                            @input="${(x, c) => x.handleTextValueInput("g", c.event)}"
-                            :value="${x => Math.round(x.uiValues.RGBColor.g * 255)}"
-                        >
-                            <span slot="start">G:</span>
-                        </${context.tagFor(TextField)}>
-                        <${context.tagFor(TextField)}
-                            maxlength="3"
-                            size="3"
-                            @input="${(x, c) => x.handleTextValueInput("b", c.event)}"
-                            :value="${x => Math.round(x.uiValues.RGBColor.b * 255)}"
-                        >
-                            <span slot="start">B:</span>
-                        </${context.tagFor(TextField)}>
-
-                        <${context.tagFor(TextField)}
-                            maxlength="3"
-                            size="3"
-                            @input="${(x, c) => x.handleTextValueInput("h", c.event)}"
-                            :value="${x => Math.round(x.uiValues.HSVColor.h)}"
-                        >
-                            <span slot="start">H:</span>
-                        </${context.tagFor(TextField)}>
-                        <${context.tagFor(TextField)}
-                            maxlength="3"
-                            size="3"
-                            @input="${(x, c) => x.handleTextValueInput("s", c.event)}"
-                            :value="${x => Math.round(x.uiValues.HSVColor.s * 100)}"
-                        >
-                            <span slot="start">S:</span>
-                        </${context.tagFor(TextField)}>
-                        <${context.tagFor(TextField)}
-                            maxlength="3"
-                            size="3"
-                            @input="${(x, c) => x.handleTextValueInput("v", c.event)}"
-                            :value="${x => Math.round(x.uiValues.HSVColor.v * 100)}"
-                        >
-                            <span slot="start">V:</span>
-                        </${context.tagFor(TextField)}>
-                        <${context.tagFor(TextField)}
-                            maxlength="3"
-                            size="3"
-                            @input="${(x, c) => x.handleTextValueInput("a", c.event)}"
-                            :value="${x => Math.round(x.uiValues.RGBColor.a * 100)}"
-                        >
-                            <span slot="start">A:</span>
-                        </${context.tagFor(TextField)}>
+                        <div class="${dtcClassName.textFieldControl}">
+                            <span>R:</span>
+                            <input
+                                class="${dtcClassName.commonDefaultFont} ${dtcClassName.commonInput}"
+                                maxlength="3"
+                                size="3"
+                                @input="${(x, c) => x.handleTextValueInput("r", c.event)}"
+                                :value="${x => Math.round(x.uiValues.RGBColor.r * 255)}"
+                            />
+                        </div>
+                        <div class="${dtcClassName.textFieldControl}">
+                            <span>G:</span>
+                            <input
+                                class="${dtcClassName.commonDefaultFont} ${dtcClassName.commonInput}"
+                                maxlength="3"
+                                size="3"
+                                @input="${(x, c) => x.handleTextValueInput("g", c.event)}"
+                                :value="${x => Math.round(x.uiValues.RGBColor.g * 255)}"
+                            />
+                        </div>
+                        <div class="${dtcClassName.textFieldControl}">
+                            <span>B:</span>
+                            <input
+                                class="${dtcClassName.commonDefaultFont} ${dtcClassName.commonInput}"
+                                maxlength="3"
+                                size="3"
+                                @input="${(x, c) => x.handleTextValueInput("b", c.event)}"
+                                :value="${x => Math.round(x.uiValues.RGBColor.b * 255)}"
+                            />
+                        </div>
+                        <div class="${dtcClassName.textFieldControl}">
+                            <span>H:</span>
+                            <input
+                                class="${dtcClassName.commonDefaultFont} ${dtcClassName.commonInput}"
+                                maxlength="3"
+                                size="3"
+                                @input="${(x, c) => x.handleTextValueInput("h", c.event)}"
+                                :value="${x => Math.round(x.uiValues.HSVColor.h)}"
+                            />
+                        </div>
+                        <div class="${dtcClassName.textFieldControl}">
+                            <span>S:</span>
+                            <input
+                                class="${dtcClassName.commonDefaultFont} ${dtcClassName.commonInput}"
+                                maxlength="3"
+                                size="3"
+                                @input="${(x, c) => x.handleTextValueInput("s", c.event)}"
+                                :value="${x => Math.round(x.uiValues.HSVColor.s * 100)}"
+                            />
+                        </div>
+                        <div class="${dtcClassName.textFieldControl}">
+                            <span>V:</span>
+                            <input
+                                class="${dtcClassName.commonDefaultFont} ${dtcClassName.commonInput}"
+                                maxlength="3"
+                                size="3"
+                                @input="${(x, c) => x.handleTextValueInput("v", c.event)}"
+                                :value="${x => Math.round(x.uiValues.HSVColor.v * 100)}"
+                            />
+                        </div>
+                        <div class="${dtcClassName.textFieldControl}">
+                            <span>A:</span>
+                            <input
+                                class="${dtcClassName.commonDefaultFont} ${dtcClassName.commonInput}"
+                                maxlength="3"
+                                size="3"
+                                @input="${(x, c) => x.handleTextValueInput("a", c.event)}"
+                                :value="${x => Math.round(x.uiValues.RGBColor.a * 100)}"
+                            />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/packages/design-to-code/src/web-components/color-picker/color-picker.ts
+++ b/packages/design-to-code/src/web-components/color-picker/color-picker.ts
@@ -12,10 +12,6 @@ import { FormAssociatedColorPicker } from "./color-picker.form-associated.js";
 /**
  * This is currently experimental, any use of the color picker must include the following
  * imports and register with the DesignSystem
- *
- * import { fastTextField } from "@microsoft/fast-components";
- * import { DesignSystem } from "@microsoft/fast-foundation";
- * DesignSystem.getOrCreate().register(fastTextField());
  */
 
 /**
@@ -47,6 +43,24 @@ class ColorPickerUI {
  * @public
  */
 export class ColorPicker extends FormAssociatedColorPicker {
+    /**
+     * The text-field stylesheet path
+     */
+    @attr({ attribute: "control-text-field-stylesheet" })
+    public controlTextFieldStylesheet: string;
+
+    /**
+     * The common default font stylesheet path
+     */
+    @attr({ attribute: "common-default-font-stylesheet" })
+    public commonDefaultFontStylesheet: string;
+
+    /**
+     * The common input stylesheet path
+     */
+    @attr({ attribute: "common-input-stylesheet" })
+    public commonInputStylesheet: string;
+
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public

--- a/packages/design-to-code/src/web-components/file/file.template.ts
+++ b/packages/design-to-code/src/web-components/file/file.template.ts
@@ -13,9 +13,9 @@ export const FileTemplate: (
     return html`
         <template>
             <div class="root" part="root">
-                <link rel="stylesheet" href="${x => x.controlButtonStylesheet}" />
                 <link rel="stylesheet" href="${x => x.commonInputStylesheet}" />
                 <link rel="stylesheet" href="${x => x.commonDefaultFontStylesheet}" />
+                <link rel="stylesheet" href="${x => x.controlButtonStylesheet}" />
                 <button
                     class="${x => {
                         return x.disabled

--- a/packages/design-to-code/src/web-components/style/class-names.ts
+++ b/packages/design-to-code/src/web-components/style/class-names.ts
@@ -1,6 +1,8 @@
 const dtcClassName = {
     buttonControl: "dtc-button-control",
     buttonControl__disabled: "dtc-button-control__disabled",
+    textFieldControl: "dtc-text-field-control",
+    textFieldControl__disabled: "dtc-text-field-control__disabled",
     commonInput: "dtc-common-input",
     commonDefaultFont: "dtc-common-default-font",
 } as const;

--- a/packages/design-to-code/src/web-components/style/common.default-font.css
+++ b/packages/design-to-code/src/web-components/style/common.default-font.css
@@ -1,4 +1,3 @@
 .dtc-common-default-font {
-    color: var(--dtc-inactive-text-color);
-    font-style: italic;
+    color: var(--dtc-text-color);
 }

--- a/packages/design-to-code/src/web-components/style/common.input.css
+++ b/packages/design-to-code/src/web-components/style/common.input.css
@@ -3,8 +3,9 @@
     background: none;
     border: none;
     margin: 0;
-    height: 18px;
+    padding: 4px 6px;
     border-radius: var(--dtc-border-radius);
+    height: 24px;
 }
 
 .dtc-common-input:focus-visible {

--- a/packages/design-to-code/src/web-components/style/control.button.css
+++ b/packages/design-to-code/src/web-components/style/control.button.css
@@ -1,5 +1,9 @@
-button.dtc-button-control {
+.dtc-button-control {
     text-align: start;
     background: var(--dtc-l1-color);
-    padding: 4px 12px;
+}
+
+.dtc-button-control.dtc-button-control__disabled {
+    color: var(--dtc-inactive-text-color);
+    font-style: italic;
 }

--- a/packages/design-to-code/src/web-components/style/control.text-field.css
+++ b/packages/design-to-code/src/web-components/style/control.text-field.css
@@ -1,0 +1,20 @@
+.dtc-text-field-control {
+    display: flex;
+    align-items: center;
+}
+
+.dtc-text-field-control input {
+    width: 100%;
+    border: none;
+    outline: none;
+    font-size: var(--dtc-text-size-default);
+    box-sizing: border-box;
+    line-height: 16px;
+    font-family: inherit;
+    background-color: var(--dtc-l1-color);
+}
+
+.dtc-text-field-control.dtc-text-field-control__disabled input {
+    color: var(--dtc-inactive-text-color);
+    font-style: italic;
+}

--- a/packages/design-to-code/src/web-components/style/global.css-variables.css
+++ b/packages/design-to-code/src/web-components/style/global.css-variables.css
@@ -6,7 +6,7 @@ body, html {
     --dtc-l3-fill-color: #4D4D4D;
     --dtc-l4-color: #1B1B1B;
     --dtc-floating-color: #3B3B3B;
-    --dtc-accent-color: #FF4387;
+    --dtc-accent-color: #65A1FA;
     --dtc-text-color: #F7F7F7;
     --dtc-inactive-text-color: #A2A2A2;
     --dtc-error-color: red;


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change:
- Removes the dependency on the `@microsoft/fast-components` text-field component
- Adjust styling to match with the file component
- Update method for importing stylesheets in the examples apps for both components

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Continue remove references to `@microsoft/fast-components`