### PR TITLE
Convert templates from class component to function

### DIFF
--- a/change/design-to-code-react-d7f96ecb-c53a-4b06-9d80-1dcc7ad3fe02.json
+++ b/change/design-to-code-react-d7f96ecb-c53a-4b06-9d80-1dcc7ad3fe02.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Package is not yet published",
+  "packageName": "design-to-code-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/design-to-code-react/src/form/templates/index.ts
+++ b/packages/design-to-code-react/src/form/templates/index.ts
@@ -1,5 +1,5 @@
 import { ControlType } from "./types";
-import ControlTemplateUtilities from "./template.control.utilities";
+import * as ControlTemplateUtilities from "./template.control.utilities";
 import StandardControlTemplate from "./template.control.standard";
 import { StandardControlPlugin } from "./plugin.control.standard";
 import SingleLineControlTemplate from "./template.control.single-line";

--- a/packages/design-to-code-react/src/form/templates/template.control.bare.tsx
+++ b/packages/design-to-code-react/src/form/templates/template.control.bare.tsx
@@ -1,24 +1,37 @@
 import React from "react";
-import ControlTemplateUtilities from "./template.control.utilities";
+import { getConfig } from "./template.control.utilities";
 import { BareControlTemplateProps } from "./template.control.bare.props";
 import { classNames } from "@microsoft/fast-web-utilities";
+import { FormHTMLElement } from "./template.control.utilities.props";
 
 /**
  * Control template definition
  */
-class BareControlTemplate extends ControlTemplateUtilities<BareControlTemplateProps, {}> {
-    public render(): React.ReactNode {
-        return (
-            <div
-                className={classNames("dtc-bare-control-template", [
-                    "dtc-bare-control-template__disabled",
-                    this.props.disabled,
-                ])}
-            >
-                {this.props.control(this.getConfig())}
-            </div>
-        );
+function BareControlTemplate(props: BareControlTemplateProps) {
+    const ref: React.RefObject<FormHTMLElement> = React.createRef<FormHTMLElement>();
+    let cache: any = undefined;
+
+    function setCache(updatedCache: any): void {
+        cache = updatedCache;
     }
+
+    const aggregateProps = {
+        ...props,
+        ref,
+        cache,
+        setCache,
+    };
+
+    return (
+        <div
+            className={classNames("dtc-bare-control-template", [
+                "dtc-bare-control-template__disabled",
+                props.disabled,
+            ])}
+        >
+            {props.control(getConfig(aggregateProps))}
+        </div>
+    );
 }
 
 export { BareControlTemplate };

--- a/packages/design-to-code-react/src/form/templates/template.control.single-line.tsx
+++ b/packages/design-to-code-react/src/form/templates/template.control.single-line.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import ControlTemplateUtilities from "./template.control.utilities";
+import {
+    getConfig,
+    renderBadge,
+    renderDefaultValueIndicator,
+    renderInvalidMessage,
+    renderSoftRemove,
+} from "./template.control.utilities";
 import { SingleLineControlTemplateProps } from "./template.control.single-line.props";
 import { classNames } from "@microsoft/fast-web-utilities";
 import cssVariables from "../../style/css-variables.css";
@@ -12,6 +18,7 @@ import invalidMessageStyle from "../../style/invalid-message-style.css";
 import softRemoveStyle from "../../style/soft-remove-style.css";
 import softRemoveInputStyle from "../../style/soft-remove-input-style.css";
 import style from "./template.control.single-line.style.css";
+import { FormHTMLElement } from "./template.control.utilities.props";
 
 // tree-shaking
 cssVariables;
@@ -28,55 +35,70 @@ style;
 /**
  * Control template definition
  */
-class SingleLineControlTemplate extends ControlTemplateUtilities<
-    SingleLineControlTemplateProps,
-    {}
-> {
-    public render(): React.ReactNode {
-        return (
+function SingleLineControlTemplate(props: SingleLineControlTemplateProps) {
+    const ref: React.RefObject<FormHTMLElement> = React.createRef<FormHTMLElement>();
+    let cache: any = undefined;
+
+    function setCache(updatedCache: any): void {
+        cache = updatedCache;
+    }
+
+    const aggregateProps = {
+        ...props,
+        ref,
+        cache,
+        setCache,
+    };
+
+    return (
+        <div
+            className={classNames("dtc-single-line-control-template", [
+                "dtc-single-line-control-template__disabled dtc-common-form-control-disabled",
+                props.disabled,
+            ])}
+        >
             <div
-                className={classNames("dtc-single-line-control-template", [
-                    "dtc-single-line-control-template__disabled dtc-common-form-control-disabled",
-                    this.props.disabled,
-                ])}
+                className={
+                    "dtc-single-line-control-template_control dtc-common-control-single-line-wrapper"
+                }
             >
+                {props.control(getConfig(aggregateProps))}
+                <label
+                    className={"dtc-single-line-control-template_label dtc-common-label"}
+                    htmlFor={props.dataLocation}
+                    title={props.labelTooltip}
+                >
+                    {props.label}
+                </label>
+                {renderDefaultValueIndicator({
+                    className:
+                        "dtc-single-line-control-template_default-value-indicator dtc-common-interactive-form-control-indicator",
+                    ...aggregateProps,
+                })}
+                {renderBadge({
+                    className:
+                        "dtc-single-line-control-template_badge dtc-common-form-control-indicator",
+                    ...aggregateProps,
+                })}
                 <div
                     className={
-                        "dtc-single-line-control-template_control dtc-common-control-single-line-wrapper"
+                        "dtc-single-line-control-template_soft-remove dtc-common-soft-remove"
                     }
                 >
-                    {this.props.control(this.getConfig())}
-                    <label
-                        className={
-                            "dtc-single-line-control-template_label dtc-common-label"
-                        }
-                        htmlFor={this.props.dataLocation}
-                        title={this.props.labelTooltip}
-                    >
-                        {this.props.label}
-                    </label>
-                    {this.renderDefaultValueIndicator(
-                        "dtc-single-line-control-template_default-value-indicator dtc-common-interactive-form-control-indicator"
-                    )}
-                    {this.renderBadge(
-                        "dtc-single-line-control-template_badge dtc-common-form-control-indicator"
-                    )}
-                    <div
-                        className={
-                            "dtc-single-line-control-template_soft-remove dtc-common-soft-remove"
-                        }
-                    >
-                        {this.renderSoftRemove(
-                            "dtc-single-line-control-template_soft-remove-input dtc-common-soft-remove-input"
-                        )}
-                    </div>
+                    {renderSoftRemove({
+                        className:
+                            "dtc-single-line-control-template_soft-remove-input dtc-common-soft-remove-input",
+                        ...aggregateProps,
+                    })}
                 </div>
-                {this.renderInvalidMessage(
-                    "dtc-single-line-control-template_invalid-message dtc-common-invalid-message"
-                )}
             </div>
-        );
-    }
+            {renderInvalidMessage({
+                className:
+                    "dtc-single-line-control-template_invalid-message dtc-common-invalid-message",
+                ...aggregateProps,
+            })}
+        </div>
+    );
 }
 
 export { SingleLineControlTemplate };

--- a/packages/design-to-code-react/src/form/templates/template.control.standard.tsx
+++ b/packages/design-to-code-react/src/form/templates/template.control.standard.tsx
@@ -1,5 +1,12 @@
 import React from "react";
-import ControlTemplateUtilities from "./template.control.utilities";
+import {
+    getConfig,
+    renderBadge,
+    renderConstValueIndicator,
+    renderDefaultValueIndicator,
+    renderInvalidMessage,
+    renderSoftRemove,
+} from "./template.control.utilities";
 import { StandardControlTemplateProps } from "./template.control.standard.props";
 import { ControlContext } from "./types";
 import { classNames } from "@microsoft/fast-web-utilities";
@@ -16,6 +23,7 @@ import labelStyle from "../../style/label-style.css";
 import invalidMessageStyle from "../../style/invalid-message-style.css";
 import formControlIndicatorStyle from "../../style/form-control-indicator-style.css";
 import style from "./template.control.standard.style.css";
+import { FormHTMLElement } from "./template.control.utilities.props";
 
 // tree-shaking
 cssVariables;
@@ -35,84 +43,97 @@ style;
 /**
  * Control template definition
  */
-class StandardControlTemplate extends ControlTemplateUtilities<
-    StandardControlTemplateProps,
-    {}
-> {
-    public static defaultProps: Partial<StandardControlTemplateProps> = {
-        context: ControlContext.default,
+function StandardControlTemplate(props: StandardControlTemplateProps) {
+    const ref: React.RefObject<FormHTMLElement> = React.createRef<FormHTMLElement>();
+    let cache: any = undefined;
+
+    function setCache(updatedCache: any): void {
+        cache = updatedCache;
+    }
+
+    const aggregateProps = {
+        ...props,
+        ref,
+        cache,
+        setCache,
     };
 
-    public render(): React.ReactNode {
-        return (
+    function renderControl(context: ControlContext): React.ReactNode {
+        return context === props.context
+            ? props.control(getConfig({ ...aggregateProps }))
+            : null;
+    }
+
+    return (
+        <div
+            className={classNames(
+                "dtc-standard-control-template dtc-common-control-wrapper",
+                [
+                    "dtc-standard-control-template__disabled dtc-common-form-control-disabled",
+                    props.disabled,
+                ]
+            )}
+        >
             <div
-                className={classNames(
-                    "dtc-standard-control-template dtc-common-control-wrapper",
-                    [
-                        "dtc-standard-control-template__disabled dtc-common-form-control-disabled",
-                        this.props.disabled,
-                    ]
-                )}
+                className={
+                    "dtc-standard-control-template_control-region dtc-common-control-region"
+                }
             >
                 <div
-                    className={
-                        "dtc-standard-control-template_control-region dtc-common-control-region"
-                    }
+                    className={"dtc-standard-control-template_control dtc-common-control"}
                 >
                     <div
                         className={
-                            "dtc-standard-control-template_control dtc-common-control"
+                            "dtc-standard-control-template_control-label-region dtc-common-label-region"
                         }
                     >
-                        <div
+                        <label
+                            htmlFor={props.dataLocation}
                             className={
-                                "dtc-standard-control-template_control-label-region dtc-common-label-region"
+                                "dtc-standard-control-template_control-label dtc-common-label"
                             }
+                            title={props.labelTooltip}
                         >
-                            <label
-                                htmlFor={this.props.dataLocation}
-                                className={
-                                    "dtc-standard-control-template_control-label dtc-common-label"
-                                }
-                                title={this.props.labelTooltip}
-                            >
-                                {this.props.label}
-                            </label>
-                            {this.renderConstValueIndicator(
-                                "dtc-standard-control-template_const-value-indicator dtc-common-interactive-form-control-indicator"
-                            )}
-                            {this.renderDefaultValueIndicator(
-                                "dtc-standard-control-template_default-value-indicator dtc-common-interactive-form-control-indicator"
-                            )}
-                            {this.renderBadge(
-                                "dtc-standard-control-template_badge dtc-common-form-control-indicator"
-                            )}
-                        </div>
-                        {this.renderControl(ControlContext.default)}
+                            {props.label}
+                        </label>
+                        {renderConstValueIndicator({
+                            className:
+                                "dtc-standard-control-template_const-value-indicator dtc-common-interactive-form-control-indicator",
+                            ...aggregateProps,
+                        })}
+                        {renderDefaultValueIndicator({
+                            className:
+                                "dtc-standard-control-template_default-value-indicator dtc-common-interactive-form-control-indicator",
+                            ...aggregateProps,
+                        })}
+                        {renderBadge({
+                            className:
+                                "dtc-standard-control-template_badge dtc-common-form-control-indicator",
+                            ...aggregateProps,
+                        })}
                     </div>
-                    <div
-                        className={
-                            "dtc-standard-control-template_soft-remove dtc-common-soft-remove"
-                        }
-                    >
-                        {this.renderSoftRemove(
-                            "dtc-standard-control-template_soft-remove-input dtc-common-soft-remove-input"
-                        )}
-                    </div>
+                    {renderControl(ControlContext.default)}
                 </div>
-                {this.renderControl(ControlContext.fill)}
-                {this.renderInvalidMessage(
-                    "dtc-standard-control-template_invalid-message dtc-common-invalid-message"
-                )}
+                <div
+                    className={
+                        "dtc-standard-control-template_soft-remove dtc-common-soft-remove"
+                    }
+                >
+                    {renderSoftRemove({
+                        className:
+                            "dtc-standard-control-template_soft-remove-input dtc-common-soft-remove-input",
+                        ...aggregateProps,
+                    })}
+                </div>
             </div>
-        );
-    }
-
-    private renderControl(context: ControlContext): React.ReactNode {
-        return context === this.props.context
-            ? this.props.control(this.getConfig())
-            : null;
-    }
+            {renderControl(ControlContext.fill)}
+            {renderInvalidMessage({
+                className:
+                    "dtc-standard-control-template_invalid-message dtc-common-invalid-message",
+                ...aggregateProps,
+            })}
+        </div>
+    );
 }
 
 export { StandardControlTemplate };


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change updates all control templates from React class components to functions and refactors the utilities as a set of utility functions instead of an extendable class.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Continue converting the React class components to functions