### PR TITLE
Remove the text field dependency

### DIFF
--- a/change/design-to-code-6b8f1968-4193-4fc2-a736-bc5f9c5e86e2.json
+++ b/change/design-to-code-6b8f1968-4193-4fc2-a736-bc5f9c5e86e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Package has not yet been published",
+  "packageName": "design-to-code",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/design-to-code/app/examples/css-box-model/index.html
+++ b/packages/design-to-code/app/examples/css-box-model/index.html
@@ -11,21 +11,25 @@
                 width: 100%;
                 height: 100%;
                 font-family: Arial, Helvetica, sans-serif;
-                background-color: var(--fill-color);
+                background-color: var(--dtc-l4-color);
                 color: white;
             }
         </style>
+        <link
+            rel="stylesheet"
+            href="<%= htmlWebpackPlugin.options.globalCssVariableStylesheet %>"
+        />
     </head>
     <body>
         <div id="root">
             Input:
-            <input id="inputValue" type="text" style="width: 800px;" />
+            <input id="inputValue" type="text" style="width: 800px" />
             <br />
             <br />
             <dtc-css-box-model id="box_model"></dtc-css-box-model>
             <br />
             Output:
-            <input id="outputValue" type="text" style="width: 800px;" />
+            <input id="outputValue" type="text" style="width: 800px" />
         </div>
         <script>
             const boxModelElement = document.getElementById("box_model");

--- a/packages/design-to-code/app/examples/css-box-model/webpack.common.cjs
+++ b/packages/design-to-code/app/examples/css-box-model/webpack.common.cjs
@@ -62,6 +62,7 @@ module.exports = {
             title: "Test application",
             inject: "body",
             template: path.resolve(appDir, "index.html"),
+            globalCssVariableStylesheet: "/global.css-variables.css",
         }),
     ],
 };

--- a/packages/design-to-code/app/examples/units-text-field/index.html
+++ b/packages/design-to-code/app/examples/units-text-field/index.html
@@ -11,16 +11,17 @@
                 width: 100%;
                 height: 100%;
                 font-family: Arial, Helvetica, sans-serif;
-                background-color: var(--fill-color);
+                background-color: var(--dtc-l4-color);
             }
         </style>
+        <link
+            rel="stylesheet"
+            href="<%= htmlWebpackPlugin.options.globalCssVariableStylesheet %>"
+        />
     </head>
     <body>
         <div id="root">
-            <dtc-units-text-field
-                placeholder="placeholder text"
-                id="units_text_field"
-            >
+            <dtc-units-text-field placeholder="placeholder text" id="units_text_field">
                 Units Text Field
             </dtc-units-text-field>
         </div>

--- a/packages/design-to-code/app/examples/units-text-field/webpack.common.cjs
+++ b/packages/design-to-code/app/examples/units-text-field/webpack.common.cjs
@@ -62,6 +62,7 @@ module.exports = {
             title: "Test application",
             inject: "body",
             template: path.resolve(appDir, "index.html"),
+            globalCssVariableStylesheet: "/global.css-variables.css",
         }),
     ],
 };

--- a/packages/design-to-code/src/web-components/css-box-model/css-box-model.style.ts
+++ b/packages/design-to-code/src/web-components/css-box-model/css-box-model.style.ts
@@ -18,16 +18,19 @@ export const cssBoxModelStyles = css`
         display: inline-block;
         margin-bottom: 10px;
     }
-    .singleInput__hidden {
+    .single-input {
+        display: flex;
+    }
+    .single-input__hidden {
         display: none;
     }
-    .sideButton {
+    .layout-button {
         vertical-align: top;
     }
-    .sideButton path {
+    .layout-button path {
         fill: ${neutralForegroundRest};
     }
-    .sideButton__active {
+    .layout-button__active {
         background-color: ${neutralFillStealthActive};
     }
     .grid {

--- a/packages/design-to-code/src/web-components/css-box-model/css-box-model.template.ts
+++ b/packages/design-to-code/src/web-components/css-box-model/css-box-model.template.ts
@@ -21,16 +21,16 @@ const sidesButton = html`
  * The template for the box-model component.
  * @public
  */
-export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
-    CSSBoxModel
->`
+export const cssBoxModelTemplate = (
+    context: ElementDefinitionContext
+) => html<CSSBoxModel>`
     <template>
         <div class="section">
             <label for="margin" class="section-label">Margin</label>
             <br />
             <div
                 class="${x =>
-                    x.marginOpen ? "singleInput singleInput__hidden" : "singleInput"}"
+                    x.marginOpen ? "single-input single-input__hidden" : "single-input"}"
             >
                 <dtc-units-text-field
                     id="margin"
@@ -41,7 +41,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
                 ></dtc-units-text-field>
                 <fast-button
                     appearance="stealth"
-                    class="sideButton"
+                    class="layout-button"
                     @click="${(x, c) =>
                         x.handleOpenButtonClick(expandableSection.margin)}"
                 >
@@ -61,7 +61,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
                 <div class="item item-topRight">
                     <fast-button
                         appearance="stealth"
-                        class="sideButton sideButton_active"
+                        class="layout-button layout-button_active"
                         @click="${(x, c) =>
                             x.handleOpenButtonClick(expandableSection.margin)}"
                     >
@@ -104,7 +104,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
             <label for="border" class="section-label">Border Width</label>
             <div
                 class="${x =>
-                    x.borderOpen ? "singleInput singleInput__hidden" : "singleInput"}"
+                    x.borderOpen ? "single-input single-input__hidden" : "single-input"}"
             >
                 <dtc-units-text-field
                     id="border"
@@ -115,7 +115,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
                 ></dtc-units-text-field>
                 <fast-button
                     appearance="stealth"
-                    class="sideButton"
+                    class="layout-button"
                     @click="${(x, c) =>
                         x.handleOpenButtonClick(expandableSection.border)}"
                 >
@@ -136,7 +136,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
                 <div class="item item-topRight">
                     <fast-button
                         appearance="stealth"
-                        class="sideButton sideButton__active"
+                        class="layout-button layout-button__active"
                         @click="${(x, c) =>
                             x.handleOpenButtonClick(expandableSection.border)}"
                     >
@@ -191,7 +191,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
                 ></dtc-units-text-field>
                 <fast-button
                     appearance="stealth"
-                    class="sideButton"
+                    class="layout-button"
                     @click="${(x, c) =>
                         x.handleOpenButtonClick(expandableSection.padding)}"
                 >
@@ -211,7 +211,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
                 <div class="item item-topRight">
                     <fast-button
                         appearance="stealth"
-                        class="sideButton sideButton__active"
+                        class="layout-button layout-button__active"
                         @click="${(x, c) =>
                             x.handleOpenButtonClick(expandableSection.padding)}"
                     >

--- a/packages/design-to-code/src/web-components/units-text-field/index.ts
+++ b/packages/design-to-code/src/web-components/units-text-field/index.ts
@@ -1,6 +1,6 @@
 import { textFieldTemplate as template } from "@microsoft/fast-foundation";
-import { textFieldStyles as styles } from "@microsoft/fast-components";
 import { UnitsTextField } from "./units-text-field.js";
+import { UnitsTextFieldStyles as styles } from "./units-text-field.styles.js";
 
 /**
  * A web component text field that increments / decrements numeric values mixed with text when up and down arrow keys are pressed.

--- a/packages/design-to-code/src/web-components/units-text-field/units-text-field.styles.ts
+++ b/packages/design-to-code/src/web-components/units-text-field/units-text-field.styles.ts
@@ -1,0 +1,45 @@
+import { css } from "@microsoft/fast-element";
+
+export const UnitsTextFieldStyles = (context, definition) => css`
+    :host {
+        outline: none;
+        user-select: none;
+    }
+
+    .label {
+        display: block;
+        color: var(--dtc-text-color);
+        cursor: pointer;
+        font-size: var(--dtc-text-size-default);
+        margin-bottom: 4px;
+    }
+
+    .root {
+        box-sizing: border-box;
+        position: relative;
+        display: flex;
+        flex-direction: row;
+        color: var(--dtc-text-color);
+        font-size: var(--dtc-text-size-default);
+    }
+
+    .control {
+        appearance: none;
+        font-style: inherit;
+        font-variant: inherit;
+        font-weight: inherit;
+        font-stretch: inherit;
+        font-family: inherit;
+        color: inherit;
+        height: calc(100% - 4px);
+        width: 100%;
+        margin-top: auto;
+        margin-bottom: auto;
+        border: none;
+        padding: 3px 5px 2px 5px;
+        line-height: 16px;
+        font-size: var(--dtc-text-size-default);
+        border-radius: var(--dtc-border-radius);
+        background-color: var(--dtc-l1-color);
+    }
+`;


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change removes the dependency in the units text field on the text-field styles from the `@microsoft/fast-components` deprecated dependency.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Partial work on #37

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Continue removing imports from `@microsoft/fast-components` so that it can be removed as a dependency