### PR TITLE
Remove the fast-button from deprecated @microsoft/fast-components package from the css box model

### DIFF
--- a/change/design-to-code-60cb4870-ed95-42b6-8abc-9b086411cd80.json
+++ b/change/design-to-code-60cb4870-ed95-42b6-8abc-9b086411cd80.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Package has yet to be published",
+  "packageName": "design-to-code",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/design-to-code/app/examples/css-box-model/index.ts
+++ b/packages/design-to-code/app/examples/css-box-model/index.ts
@@ -1,8 +1,7 @@
-import { provideFASTDesignSystem, fastButton } from "@microsoft/fast-components";
+import { provideFASTDesignSystem } from "@microsoft/fast-components";
 import { cssBoxModelComponent } from "../../../src/web-components/css-box-model/index.js";
 import { unitsTextFieldComponent } from "../../../src/web-components/units-text-field/index.js";
 
 provideFASTDesignSystem()
     .withPrefix("dtc")
-    .register(fastButton())
     .register(unitsTextFieldComponent(), cssBoxModelComponent());

--- a/packages/design-to-code/src/web-components/css-box-model/css-box-model.style.ts
+++ b/packages/design-to-code/src/web-components/css-box-model/css-box-model.style.ts
@@ -1,8 +1,3 @@
-import {
-    neutralFillStealthActive,
-    neutralForegroundRest,
-    typeRampBaseFontSize,
-} from "@microsoft/fast-components";
 import { css } from "@microsoft/fast-element";
 
 export const cssBoxModelStyles = css`
@@ -25,18 +20,24 @@ export const cssBoxModelStyles = css`
         display: none;
     }
     .layout-button {
+        display: flex;
+        border-radius: var(--dtc-border-radius);
         vertical-align: top;
+        background: none;
+        border: 0px;
+        padding: 1px 4px;
+        margin-top: 4px;
     }
     .layout-button path {
-        fill: ${neutralForegroundRest};
+        fill: var(--dtc-text-color);
     }
     .layout-button__active {
-        background-color: ${neutralFillStealthActive};
+        background-color: var(--dtc-accent-color);
     }
     .grid {
         display: grid;
         grid-template-columns: 33% 33% 33%;
-        color: ${neutralForegroundRest};
+        color: var(--dtc-text-color);
     }
     .grid-dimension {
         grid-template-columns: 50% 50%;
@@ -54,14 +55,14 @@ export const cssBoxModelStyles = css`
     .item-label {
         overflow: visible;
         justify-content: start;
-        font-size: ${typeRampBaseFontSize};
+        font-size: var(--dtc-text-size-default);
         width: 25px;
     }
     .item-top {
         grid-row: 1;
         grid-column: 2;
     }
-    .item-topRight {
+    .item-top-right {
         grid-column: 3;
         justify-content: right;
     }

--- a/packages/design-to-code/src/web-components/css-box-model/css-box-model.template.ts
+++ b/packages/design-to-code/src/web-components/css-box-model/css-box-model.template.ts
@@ -39,14 +39,13 @@ export const cssBoxModelTemplate = (
                     :value="${x => x.uiValues.margin.getCSSShorthandFourValues()}"
                     @change="${(x, c) => x.handleInputChange("margin", c.event)}"
                 ></dtc-units-text-field>
-                <fast-button
-                    appearance="stealth"
+                <button
                     class="layout-button"
                     @click="${(x, c) =>
                         x.handleOpenButtonClick(expandableSection.margin)}"
                 >
                     ${sidesButton}
-                </fast-button>
+                </button>
             </div>
             <div class="${x => (x.marginOpen ? "grid" : "grid grid__hidden")}">
                 <div class="item item-top">
@@ -58,15 +57,14 @@ export const cssBoxModelTemplate = (
                         @change="${(x, c) => x.handleInputChange("margin-top", c.event)}"
                     ></dtc-units-text-field>
                 </div>
-                <div class="item item-topRight">
-                    <fast-button
-                        appearance="stealth"
-                        class="layout-button layout-button_active"
+                <div class="item item-top-right">
+                    <button
+                        class="layout-button layout-button__active"
                         @click="${(x, c) =>
                             x.handleOpenButtonClick(expandableSection.margin)}"
                     >
                         ${sidesButton}
-                    </fast-button>
+                    </button>
                 </div>
                 <div class="item item-left">
                     <dtc-units-text-field
@@ -113,14 +111,13 @@ export const cssBoxModelTemplate = (
                     :value="${x => x.uiValues.borderWidth.getCSSShorthandFourValues()}"
                     @change="${(x, c) => x.handleInputChange("border-width", c.event)}"
                 ></dtc-units-text-field>
-                <fast-button
-                    appearance="stealth"
+                <button
                     class="layout-button"
                     @click="${(x, c) =>
                         x.handleOpenButtonClick(expandableSection.border)}"
                 >
                     ${sidesButton}
-                </fast-button>
+                </button>
             </div>
             <div class="${x => (x.borderOpen ? "grid" : "grid grid__hidden")}">
                 <div class="item item-top">
@@ -133,15 +130,14 @@ export const cssBoxModelTemplate = (
                             x.handleInputChange("border-top-width", c.event)}"
                     ></dtc-units-text-field>
                 </div>
-                <div class="item item-topRight">
-                    <fast-button
-                        appearance="stealth"
+                <div class="item item-top-right">
+                    <button
                         class="layout-button layout-button__active"
                         @click="${(x, c) =>
                             x.handleOpenButtonClick(expandableSection.border)}"
                     >
                         ${sidesButton}
-                    </fast-button>
+                    </button>
                 </div>
                 <div class="item item-left">
                     <dtc-units-text-field
@@ -180,7 +176,7 @@ export const cssBoxModelTemplate = (
             <label for="padding" class="section-label">Padding</label>
             <div
                 class="${x =>
-                    x.paddingOpen ? "singleInput singleInput__hidden" : "singleInput"}"
+                    x.paddingOpen ? "single-input single-input__hidden" : "single-input"}"
             >
                 <dtc-units-text-field
                     id="padding"
@@ -189,14 +185,13 @@ export const cssBoxModelTemplate = (
                     :value="${x => x.uiValues.padding.getCSSShorthandFourValues()}"
                     @change="${(x, c) => x.handleInputChange("padding", c.event)}"
                 ></dtc-units-text-field>
-                <fast-button
-                    appearance="stealth"
+                <button
                     class="layout-button"
                     @click="${(x, c) =>
                         x.handleOpenButtonClick(expandableSection.padding)}"
                 >
                     ${sidesButton}
-                </fast-button>
+                </button>
             </div>
             <div class="${x => (x.paddingOpen ? "grid" : "grid grid__hidden")}">
                 <div class="item item-top">
@@ -208,15 +203,14 @@ export const cssBoxModelTemplate = (
                         @change="${(x, c) => x.handleInputChange("padding-top", c.event)}"
                     ></dtc-units-text-field>
                 </div>
-                <div class="item item-topRight">
-                    <fast-button
-                        appearance="stealth"
+                <div class="item item-top-right">
+                    <button
                         class="layout-button layout-button__active"
                         @click="${(x, c) =>
                             x.handleOpenButtonClick(expandableSection.padding)}"
                     >
                         ${sidesButton}
-                    </fast-button>
+                    </button>
                 </div>
                 <div class="item item-left">
                     <dtc-units-text-field


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change removes the inclusion of the `<fast-button>` from the deprecated `@microsoft/fast-components` package and replaces it with a standard html `<button>`.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Continued work on #37 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Continue removing imports from `@microsoft/fast-components`