### PR TITLE
Removed the toggle from CSS layout web component

### DIFF
--- a/change/design-to-code-f9a76c9d-8a90-497e-8e6b-67b58862e164.json
+++ b/change/design-to-code-f9a76c9d-8a90-497e-8e6b-67b58862e164.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Package not yet published",
+  "packageName": "design-to-code",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/design-to-code/app/examples/css-layout/index.html
+++ b/packages/design-to-code/app/examples/css-layout/index.html
@@ -5,6 +5,16 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title><%= htmlWebpackPlugin.options.title %></title>
         <style>
+            html,
+            body,
+            #root {
+                width: 100%;
+                height: 100%;
+                font-family: Arial, Helvetica, sans-serif;
+                background-color: var(--dtc-l4-color);
+                color: white;
+            }
+
             .content {
                 background-color: pink;
                 overflow: auto;
@@ -38,11 +48,18 @@
                 border: solid 1px black;
             }
         </style>
+        <link
+            rel="stylesheet"
+            href="<%= htmlWebpackPlugin.options.globalCssVariableStylesheet %>"
+        />
         <style id="custom"></style>
     </head>
     <body>
         <div id="root">
-            <dtc-css-layout id="dtc-css-layout-control"></dtc-css-layout>
+            <dtc-css-layout
+                id="dtc-css-layout-control"
+                control-toggle-stylesheet="<%= htmlWebpackPlugin.options.controlToggleStylesheet %>"
+            ></dtc-css-layout>
             <div class="content">
                 <div class="item">Item 1</div>
                 <div class="item">Item 2</div>
@@ -78,7 +95,9 @@
         </div>
         <script>
             const customStyleElement = document.getElementById("custom");
-            const cssLayoutControlElement = document.getElementById("dtc-css-layout-control");
+            const cssLayoutControlElement = document.getElementById(
+                "dtc-css-layout-control"
+            );
 
             cssLayoutControlElement.addEventListener("change", e => {
                 customStyleElement.innerText = ".content { " + e.target.value + " }";

--- a/packages/design-to-code/app/examples/css-layout/index.ts
+++ b/packages/design-to-code/app/examples/css-layout/index.ts
@@ -1,7 +1,4 @@
-import { fastSwitch, fastTooltip } from "@microsoft/fast-components";
 import { DesignSystem } from "@microsoft/fast-foundation";
 import { cssLayoutComponent } from "../../../src/web-components/css-layout/index.js";
 
-DesignSystem.getOrCreate()
-    .withPrefix("dtc")
-    .register(fastSwitch(), fastTooltip(), cssLayoutComponent());
+DesignSystem.getOrCreate().withPrefix("dtc").register(cssLayoutComponent());

--- a/packages/design-to-code/app/examples/css-layout/webpack.common.cjs
+++ b/packages/design-to-code/app/examples/css-layout/webpack.common.cjs
@@ -62,6 +62,8 @@ module.exports = {
             title: "Test application",
             inject: "body",
             template: path.resolve(appDir, "index.html"),
+            globalCssVariableStylesheet: "/global.css-variables.css",
+            controlToggleStylesheet: "/control.toggle.css",
         }),
     ],
 };

--- a/packages/design-to-code/src/web-components/css-layout/css-layout.styles.ts
+++ b/packages/design-to-code/src/web-components/css-layout/css-layout.styles.ts
@@ -1,11 +1,5 @@
 import { css } from "@microsoft/fast-element";
 
-const radioBackgroundColor = "#222";
-const activeRadioBackgroundColor = "#333";
-const numberfieldBorderColor = "#333";
-const activeRadioBorderColor = "#282828";
-const borderRadius = "3px";
-
 export const cssLayoutStyles = css`
     :host {
         display: flex;
@@ -20,21 +14,21 @@ export const cssLayoutStyles = css`
         margin: 10px 0 5px;
     }
 
-    .flexboxRegion {
+    .flexbox-region {
         display: none;
     }
 
-    .flexboxRegion__active {
+    .flexbox-region__active {
         display: block;
     }
 
-    .controlRegion,
-    .controlRegion-row {
+    .control-region,
+    .control-region-row {
         display: flex;
         flex-direction: column;
     }
 
-    .controlRegion-row {
+    .control-region-row {
         flex-direction: row;
     }
 
@@ -56,7 +50,7 @@ export const cssLayoutStyles = css`
         outline: none;
         border: none;
         width: 40px;
-        border-left: 1px solid ${numberfieldBorderColor};
+        border-left: 1px solid var(--dtc-l3-outline-color);
         color: #fff;
     }
 
@@ -66,34 +60,42 @@ export const cssLayoutStyles = css`
 
     .numberfield-item {
         display: flex;
-        border: 1px solid ${numberfieldBorderColor};
-        border-radius: ${borderRadius};
+        border: 1px solid var(--dtc-l3-outline-color);
+        border-radius: var(--dtc-border-radius);
     }
 
-    .radioRegion {
+    .radio-region {
         display: flex;
-        column-gap: 2px;
+        column-gap: 4px;
     }
 
-    .radioRegion-contentItem {
-        background: ${radioBackgroundColor};
-        border-radius: ${borderRadius};
-        border: 3px solid #1b1b1b;
+    .radio-region-content-item {
+        background: var(--dtc-l1-color);
+        border-radius: var(--dtc-border-radius);
         position: relative;
         height: 24px;
         max-width: 24px;
     }
 
-    .radioRegion-contentItem__active {
-        background: ${activeRadioBackgroundColor};
-        border-color: ${activeRadioBorderColor};
+    .radio-region-content-item__active {
+        background: var(--dtc-accent-color);
     }
 
-    .radioRegion-input {
+    .radio-region-input {
         width: 24px;
         height: 24px;
         margin: 0;
         opacity: 0;
+    }
+
+    [role="tooltip"] {
+        display: none;
+        font-size: var(--dtc-text-size-default);
+    }
+
+    .radio-region-input:hover + [role="tooltip"],
+    .radio-region-inputbutton:focus + [role="tooltip"] {
+        display: block;
     }
 
     svg {

--- a/packages/design-to-code/src/web-components/css-layout/css-layout.template.ts
+++ b/packages/design-to-code/src/web-components/css-layout/css-layout.template.ts
@@ -1,4 +1,3 @@
-import { Tooltip } from "@microsoft/fast-components";
 import { html, repeat } from "@microsoft/fast-element";
 import { ElementDefinitionContext, Switch } from "@microsoft/fast-foundation";
 import { CSSLayout } from "./css-layout.js";
@@ -531,29 +530,34 @@ const columnGap = html`
  */
 export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSSLayout>`
     <template>
-        <div class="controlRegion">
-            <${context.tagFor(Switch)}
+        <link rel="stylesheet" href="${x => x.controlToggleStylesheet}" />
+        <div class="control-region dtc-toggle-control">
+            <input
+                id="enable-flexbox"
+                class=""
+                type="checkbox"
                 :checked="${x => x.flexEnabled}"
                 @keypress="${(x, c) =>
                     x.handleKeypressToggleCSSLayout(c.event as KeyboardEvent)}"
                 @click="${(x, c) => x.handleClickToggleCSSLayout()}"
-            >
-                Enable Flexbox
-            </${context.tagFor(Switch)}>
+            />
+            <label for="enable-flexbox">Enable Flexbox</label>
         </div>
-        <div class="${x => (x.flexEnabled ? `flexboxRegion__active` : "flexboxRegion")}">
-            <div class="controlRegion">
-                <label for="dtc-css-flex-direction">Direction</label>
-                <div class="radioRegion">
+        <div
+            class="${x => (x.flexEnabled ? `flexbox-region__active` : "flexbox-region")}"
+        >
+            <div class="control-region">
+                <label for="css-flex-direction">Direction</label>
+                <div class="radio-region">
                     ${repeat(
                         x => x.flexDirectionOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="radioRegion-contentItem ${(x, c) =>
+                                class="radio-region-content-item ${(x, c) =>
                                     c.parent.flexDirectionName} ${x => x} ${(x, c) =>
-                            x === c.parent.flexDirectionValue
-                                ? "radioRegion-contentItem__active"
-                                : ""}"
+                                    x === c.parent.flexDirectionValue
+                                        ? "radio-region-content-item__active"
+                                        : ""}"
                             >
                                 ${x =>
                                     x === "row"
@@ -570,8 +574,8 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             x
                                         )}"
                                     type="radio"
-                                    class="radioRegion-input"
-                                    aria-label="${x => x}"
+                                    class="radio-region-input"
+                                    aria-labelledby="${x => x}-tooltip"
                                     name="${(x, c) => c.parent.flexDirectionName}"
                                     value="${x => x}"
                                     ?checked="${(x, c) =>
@@ -587,32 +591,30 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             c.event as MouseEvent
                                         )}"
                                 />
-                                <${context.tagFor(Tooltip)}
-                                    anchor="${(x, c) =>
-                                        c.parent.getInputId(
-                                            c.parent.flexDirectionName,
-                                            x
-                                        )}"
+                                <div
+                                    class="tooltip"
+                                    role="tooltip"
+                                    id="${x => x}-tooltip"
                                 >
                                     ${x => x}
-                                </${context.tagFor(Tooltip)}>
+                                </div>
                             </div>
                         `
                     )}
                 </div>
             </div>
-            <div class="controlRegion">
-                <label for="dtc-css-justify-content">Justify Content</label>
-                <div class="radioRegion">
+            <div class="control-region">
+                <label for="css-justify-content">Justify Content</label>
+                <div class="radio-region">
                     ${repeat(
                         x => x.justifyContentOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="radioRegion-contentItem ${(x, c) =>
+                                class="radio-region-content-item ${(x, c) =>
                                     c.parent.justifyContentName} ${x => x} ${(x, c) =>
-                            x === c.parent.justifyContentValue
-                                ? "radioRegion-contentItem__active"
-                                : ""}"
+                                    x === c.parent.justifyContentValue
+                                        ? "radio-region-content-item__active"
+                                        : ""}"
                             >
                                 ${x =>
                                     x === "flex-start"
@@ -633,8 +635,8 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             x
                                         )}"
                                     type="radio"
-                                    class="radioRegion-input"
-                                    aria-label="${x => x}"
+                                    class="radio-region-input"
+                                    aria-labelledby="${x => x}-tooltip"
                                     name="${(x, c) => c.parent.justifyContentName}"
                                     value="${x => x}"
                                     ?checked="${(x, c) =>
@@ -650,32 +652,30 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             c.event as MouseEvent
                                         )}"
                                 />
-                                <${context.tagFor(Tooltip)}
-                                    anchor="${(x, c) =>
-                                        c.parent.getInputId(
-                                            c.parent.justifyContentName,
-                                            x
-                                        )}"
+                                <div
+                                    class="tooltip"
+                                    role="tooltip"
+                                    id="${x => x}-tooltip"
                                 >
                                     ${x => x}
-                                </${context.tagFor(Tooltip)}>
+                                </div>
                             </div>
                         `
                     )}
                 </div>
             </div>
-            <div class="controlRegion">
-                <label for="dtc-css-align-content">Align Content</label>
-                <div class="radioRegion">
+            <div class="control-region">
+                <label for="css-align-content">Align Content</label>
+                <div class="radio-region">
                     ${repeat(
                         x => x.alignContentOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="radioRegion-contentItem ${(x, c) =>
+                                class="radio-region-content-item ${(x, c) =>
                                     c.parent.alignContentName} ${x => x} ${(x, c) =>
-                            x === c.parent.alignContentValue
-                                ? "radioRegion-contentItem__active"
-                                : ""}"
+                                    x === c.parent.alignContentValue
+                                        ? "radio-region-content-item__active"
+                                        : ""}"
                             >
                                 ${x =>
                                     x === "flex-start"
@@ -698,8 +698,8 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             x
                                         )}"
                                     type="radio"
-                                    class="radioRegion-input"
-                                    aria-label="${x => x}"
+                                    class="radio-region-input"
+                                    aria-labelledby="${x => x}-tooltip"
                                     name="${(x, c) => c.parent.alignContentName}"
                                     value="${x => x}"
                                     ?checked="${(x, c) =>
@@ -715,32 +715,30 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             c.event as MouseEvent
                                         )}"
                                 />
-                                <${context.tagFor(Tooltip)}
-                                    anchor="${(x, c) =>
-                                        c.parent.getInputId(
-                                            c.parent.alignContentName,
-                                            x
-                                        )}"
+                                <div
+                                    class="tooltip"
+                                    role="tooltip"
+                                    id="${x => x}-tooltip"
                                 >
                                     ${x => x}
-                                </${context.tagFor(Tooltip)}>
+                                </div>
                             </div>
                         `
                     )}
                 </div>
             </div>
-            <div class="controlRegion">
-                <label for="dtc-css-align-items">Align Items</label>
-                <div class="radioRegion">
+            <div class="control-region">
+                <label for="css-align-items">Align -items</label>
+                <div class="radio-region">
                     ${repeat(
                         x => x.alignItemsOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="radioRegion-contentItem ${(x, c) =>
+                                class="radio-region-content-item ${(x, c) =>
                                     c.parent.alignItemsName} ${x => x} ${(x, c) =>
-                            x === c.parent.alignItemsValue
-                                ? "radioRegion-contentItem__active"
-                                : ""}"
+                                    x === c.parent.alignItemsValue
+                                        ? "radio-region-content-item__active"
+                                        : ""}"
                             >
                                 ${x =>
                                     x === "flex-start"
@@ -754,8 +752,8 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                     id="${(x, c) =>
                                         c.parent.getInputId(c.parent.alignItemsName, x)}"
                                     type="radio"
-                                    class="radioRegion-input"
-                                    aria-label="${x => x}"
+                                    class="radio-region-input"
+                                    aria-labelled-by="${x => x}-tooltip"
                                     name="${(x, c) => c.parent.alignItemsName}"
                                     value="${x => x}"
                                     ?checked="${(x, c) => c.parent.alignItemsValue === x}"
@@ -770,30 +768,29 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             c.event as MouseEvent
                                         )}"
                                 />
-                                <${context.tagFor(Tooltip)}
-                                    anchor="${(x, c) =>
-                                        c.parent.getInputId(c.parent.alignItemsName, x)}"
+                                <div
+                                    class="tooltip"
+                                    role="tooltip"
+                                    id="${x => x}-tooltip"
                                 >
                                     ${x => x}
-                                </${context.tagFor(Tooltip)}>
+                                </div>
                             </div>
                         `
                     )}
                 </div>
             </div>
-            <div class="controlRegion-row">
+            <div class="control-region-row">
                 <div class="numberfield">
                     <div>
-                        <label for="dtc-css-row-gap">Row gap</label>
+                        <label for="css-row-gap">Row gap</label>
                         <div class="numberfield-item">
-                            <div class="numberfield-icon">
-                                ${rowGap}
-                            </div>
+                            <div class="numberfield-icon">${rowGap}</div>
                             <input
                                 name="${x => x.rowGapName}"
                                 class="numberfield-input"
                                 type="number"
-                                id="dtc-css-row-gap"
+                                id="css-row-gap"
                                 :value="${x => x.rowGapValue}"
                                 @input="${(x, c) =>
                                     x.handleCSSChange("rowGapValue", c.event)}"
@@ -801,16 +798,14 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                         </div>
                     </div>
                     <div>
-                        <label for="dtc-css-column-gap">Column gap</label>
+                        <label for="css-column-gap">Column gap</label>
                         <div class="numberfield-item">
-                            <div class="numberfield-icon">
-                                ${columnGap}
-                            </div>
+                            <div class="numberfield-icon">${columnGap}</div>
                             <input
                                 name="${x => x.columnGapName}"
                                 class="numberfield-input"
                                 type="number"
-                                id="dtc-css-column-gap"
+                                id="css-column-gap"
                                 :value="${x => x.columnGapValue}"
                                 @input="${(x, c) =>
                                     x.handleCSSChange("columnGapValue", c.event)}"
@@ -819,18 +814,18 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                     </div>
                 </div>
             </div>
-            <div class="controlRegion">
-                <label for="dtc-css-flex-wrap">Wrap</label>
-                <div class="radioRegion">
+            <div class="control-region">
+                <label for="css-flex-wrap">Wrap</label>
+                <div class="radio-region">
                     ${repeat(
                         x => x.flexWrapOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="radioRegion-contentItem ${(x, c) =>
+                                class="radio-region-content-item ${(x, c) =>
                                     c.parent.flexWrapName} ${x => x} ${(x, c) =>
-                            x === c.parent.flexWrapValue
-                                ? "radioRegion-contentItem__active"
-                                : ""}"
+                                    x === c.parent.flexWrapValue
+                                        ? "radio-region-content-item__active"
+                                        : ""}"
                             >
                                 ${x =>
                                     x === "wrap"
@@ -842,8 +837,8 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                     id="${(x, c) =>
                                         c.parent.getInputId(c.parent.flexWrapName, x)}"
                                     type="radio"
-                                    class="radioRegion-input"
-                                    aria-label="${x => x}"
+                                    class="radio-region-input"
+                                    aria-labelledby="${x => x}-tooltip"
                                     name="${(x, c) => c.parent.flexWrapName}"
                                     value="${x => x}"
                                     ?checked="${(x, c) => c.parent.flexWrapValue === x}"
@@ -858,12 +853,13 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             c.event as MouseEvent
                                         )}"
                                 />
-                                <${context.tagFor(Tooltip)}
-                                    anchor="${(x, c) =>
-                                        c.parent.getInputId(c.parent.flexWrapName, x)}"
+                                <div
+                                    class="tooltip"
+                                    role="tooltip"
+                                    id="${x => x}-tooltip"
                                 >
                                     ${x => x}
-                                </${context.tagFor(Tooltip)}>
+                                </div>
                             </div>
                         `
                     )}

--- a/packages/design-to-code/src/web-components/css-layout/css-layout.ts
+++ b/packages/design-to-code/src/web-components/css-layout/css-layout.ts
@@ -1,4 +1,4 @@
-import { observable } from "@microsoft/fast-element";
+import { attr, observable } from "@microsoft/fast-element";
 import { keySpace } from "@microsoft/fast-web-utilities";
 import { mapCSSInlineStyleToCSSPropertyDictionary } from "../../data-utilities/mapping.mdn-data.js";
 import { dtcPrefix } from "../utilities/index.js";
@@ -19,6 +19,12 @@ import {
  * @public
  */
 export class CSSLayout extends FormAssociatedCSSLayout {
+    /**
+     * The toggle stylesheet path
+     */
+    @attr({ attribute: "control-toggle-stylesheet" })
+    public controlToggleStylesheet: string;
+
     /**
      * When true the css-layout controls are visible
      * @internal

--- a/packages/design-to-code/src/web-components/style/control.toggle.css
+++ b/packages/design-to-code/src/web-components/style/control.toggle.css
@@ -1,0 +1,44 @@
+.dtc-toggle-control [type="checkbox"] {
+    position: absolute;
+    top: auto;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
+    width: 1px;
+    height: 1px;
+    white-space: nowrap;
+}
+.dtc-toggle-control [type="checkbox"] + label {
+    display: block;
+    position: relative;
+    padding-inline-start: 42px;
+}
+.dtc-toggle-control [type="checkbox"] + label::before,
+.dtc-toggle-control [type="checkbox"] + label::after {
+    content: "";
+    position: absolute;
+    height: 14px;
+    transition: all 0.25s ease;
+}
+.dtc-toggle-control [type="checkbox"] + label::before {
+    left: 0;
+    top: 0;
+    width: 30px;
+    background: var(--dtc-l1-color);
+    border: 2px solid var(--dtc-l1-color);
+    border-radius: var(--dtc-border-radius);
+}
+.dtc-toggle-control [type="checkbox"]:checked + label::before {
+    background: var(--dtc-accent-color);
+    border-color: var(--dtc-accent-color);
+}
+.dtc-toggle-control [type="checkbox"] + label::after {
+    left: 2px;
+    top: 2px;
+    background-color: var(--dtc-text-color);
+    background-position: center center;
+    border-radius: var(--dtc-border-radius);
+    width: 14px;
+}
+.dtc-toggle-control [type="checkbox"]:checked + label::after {
+    left: 18px;
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change:
- normalizes class names in the css layout component
- adds a stylesheet attr for the toggle control styles
- removes the toggle from `@microsoft/fast-components` as a dependency

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Continues work on #37

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Continue removing any dependencies on `@microsoft/fast-components` 