### PR TITLE
Replace deprecated web components with native elements in CSS control

### DIFF
--- a/change/design-to-code-react-62c202a4-0607-4a6c-b852-15ff5475ba27.json
+++ b/change/design-to-code-react-62c202a4-0607-4a6c-b852-15ff5475ba27.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Package not yet published",
+  "packageName": "design-to-code-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/design-to-code-react/src/form/custom-controls/control.css.tsx
+++ b/packages/design-to-code-react/src/form/custom-controls/control.css.tsx
@@ -15,29 +15,7 @@ import cssStyle from "./control.align.style.css";
 cssStyle;
 
 /**
- * This is currently experimental, any use of the CSS control must include the following
- * imports and register with the DesignSystem
- *
- * import { DesignSystem } from "@microsoft/fast-foundation";
- * import {
- *    fastCheckbox,
- *    fastNumberField,
- *    fastOption,
- *    fastSelect,
- *    fastTextField,
- * } from "@microsoft/fast-components";
- * import {
- *     colorPickerComponent,
- * } from "design-to-code/dist/esm/web-components";
- *
- * DesignSystem.getOrCreate().register(
- *    fastCheckbox(),
- *    fastNumberField(),
- *    fastOption(),
- *    fastSelect(),
- *    fastTextField(),
- *    colorPickerComponent({ prefix: "dtc" }),
- * );
+ * This is currently experimental
  */
 
 /**

--- a/packages/design-to-code-react/src/form/custom-controls/control.css.utilities.tsx
+++ b/packages/design-to-code-react/src/form/custom-controls/control.css.utilities.tsx
@@ -33,7 +33,9 @@ function getInputChangeHandler(
 
 export function renderTextInput(config: RenderRefControlConfig): JSX.Element {
     return (
-        <fast-text-field
+        <input
+            type={"text"}
+            className={"dtc-textarea-control"}
             {...{
                 key: `${config.dictionaryId}::${config.dataLocation}`,
                 events: {
@@ -45,13 +47,15 @@ export function renderTextInput(config: RenderRefControlConfig): JSX.Element {
                       }
                     : {}),
             }}
-        ></fast-text-field>
+        />
     );
 }
 
 export function renderNumber(config: RenderRefControlConfig): JSX.Element {
     return (
-        <fast-number-field
+        <input
+            type={"number"}
+            className={"dtc-number-field-control dtc-common-input"}
             {...{
                 key: `${config.dictionaryId}::${config.dataLocation}`,
                 events: {
@@ -63,13 +67,15 @@ export function renderNumber(config: RenderRefControlConfig): JSX.Element {
                       }
                     : {}),
             }}
-        ></fast-number-field>
+        />
     );
 }
 
 export function renderInteger(config: RenderRefControlConfig): JSX.Element {
     return (
-        <fast-number-field
+        <input
+            type={"number"}
+            className={"dtc-number-field-control dtc-common-input"}
             {...{
                 key: `${config.dictionaryId}::${config.dataLocation}`,
                 events: {
@@ -82,7 +88,7 @@ export function renderInteger(config: RenderRefControlConfig): JSX.Element {
                       }
                     : {}),
             }}
-        ></fast-number-field>
+        />
     );
 }
 
@@ -97,23 +103,27 @@ function getCheckboxInputChangeHandler(
 
 export function renderCheckbox(config: RenderRefControlConfig): JSX.Element {
     return (
-        <fast-checkbox
-            {...{
-                events: {
-                    change: getCheckboxInputChangeHandler(
-                        config.handleChange,
-                        config.ref.ref as string
-                    ),
-                },
-                ...(config.value
-                    ? {
-                          value: config.value,
-                      }
-                    : {}),
-            }}
-        >
-            {config.ref.ref}
-        </fast-checkbox>
+        <React.Fragment>
+            <input
+                type={"checkbox"}
+                className={"dtc-checkbox-control"}
+                {...{
+                    events: {
+                        change: getCheckboxInputChangeHandler(
+                            config.handleChange,
+                            config.ref.ref as string
+                        ),
+                    },
+                    ...(config.value
+                        ? {
+                              value: config.value,
+                          }
+                        : {}),
+                }}
+            />
+            <span className={"dtc-checkbox-control_checkmark"} />
+            <label>{config.ref.ref}</label>
+        </React.Fragment>
     );
 }
 
@@ -132,30 +142,31 @@ export function renderSelection(config: RenderSelectControlConfig): JSX.Element 
     const currentValue = currentOption ? `${currentOption.value}` : "";
 
     return (
-        <fast-select
-            key={`${config.dictionaryId}::${config.dataLocation}`}
-            events={{
-                change: getSelectionChangeHandler(config.handleChange),
-            }}
-        >
-            {config.options.map(option => {
-                return (
-                    <fast-option
-                        {...{
-                            value: `${option.value}`,
-                            key: `${config.dictionaryId}::${config.dataLocation}::${option.key}`,
-                            ...(`${option.value}` === currentValue
-                                ? {
-                                      selected: "",
-                                  }
-                                : {}),
-                        }}
-                    >
-                        {option.displayName}
-                    </fast-option>
-                );
-            })}
-        </fast-select>
+        <span className="dtc-common-select-span">
+            <select
+                className={"dtc-select-control_input dtc-common-select-input"}
+                key={`${config.dictionaryId}::${config.dataLocation}`}
+                onChange={getSelectionChangeHandler(config.handleChange)}
+            >
+                {config.options.map(option => {
+                    return (
+                        <option
+                            {...{
+                                value: `${option.value}`,
+                                key: `${config.dictionaryId}::${config.dataLocation}::${option.key}`,
+                                ...(`${option.value}` === currentValue
+                                    ? {
+                                          selected: true,
+                                      }
+                                    : {}),
+                            }}
+                        >
+                            {option.displayName}
+                        </option>
+                    );
+                })}
+            </select>
+        </span>
     );
 }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change:
- Converts the deprecated web components from the @microsoft/fast-components to native form controls using the same styling as the rest of the form controls

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
- Continued work on #37

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Remove the dependency on `@microsoft/fast-components` and update package-lock