### PR TITLE
Remove the 'only' on all playwright tests

### DIFF
--- a/change/design-to-code-941b715a-afec-4ff3-af1c-9d359d2b4bd0.json
+++ b/change/design-to-code-941b715a-afec-4ff3-af1c-9d359d2b4bd0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Package not yet published",
+  "packageName": "design-to-code",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/design-to-code/src/data-utilities/array.spec.pw.ts
+++ b/packages/design-to-code/src/data-utilities/array.spec.pw.ts
@@ -4,7 +4,7 @@ import { isInArray } from "./array.js";
 /**
  * Checks that the data is in an array
  */
-test.describe.only("isInArray", () => {
+test.describe("isInArray", () => {
     test("should return false when data is not an array and the data location is the root", () => {
         expect(isInArray({}, "")).toEqual(false);
     });

--- a/packages/design-to-code/src/data-utilities/duplicate.spec.pw.ts
+++ b/packages/design-to-code/src/data-utilities/duplicate.spec.pw.ts
@@ -4,7 +4,7 @@ import { getDataWithDuplicate } from "./duplicate.js";
 /**
  * Gets duplicated data
  */
-test.describe.only("getDataWithDuplicate", () => {
+test.describe("getDataWithDuplicate", () => {
     test("should duplicate data inside an array", () => {
         const data: any = {
             foo: ["Hello"],

--- a/packages/design-to-code/src/data-utilities/generate.spec.pw.ts
+++ b/packages/design-to-code/src/data-utilities/generate.spec.pw.ts
@@ -4,7 +4,7 @@ import { getDataFromSchema } from "./generate.js";
 /**
  * Gets an example from a schema
  */
-test.describe.only("getDataFromSchema", () => {
+test.describe("getDataFromSchema", () => {
     test("should return a default even if no type has been specified", () => {
         const schema: any = {
             default: "foo",

--- a/packages/design-to-code/src/data-utilities/mapping.mdn-data.spec.pw.ts
+++ b/packages/design-to-code/src/data-utilities/mapping.mdn-data.spec.pw.ts
@@ -19,7 +19,7 @@ import {
     resolveReferenceType,
 } from "./mapping.mdn-data.js";
 
-test.describe.only("mapStringLiterals,", () => {
+test.describe("mapStringLiterals,", () => {
     test("should keep track of '/' and ',' as literals", () => {
         expect(mapStringLiterals("/ <length-percentage>")).toEqual("/");
         expect(mapStringLiterals("<length-percentage>")).toEqual(null);
@@ -27,7 +27,7 @@ test.describe.only("mapStringLiterals,", () => {
     });
 });
 
-test.describe.only("mapCSSGroups", () => {
+test.describe("mapCSSGroups", () => {
     test("should map a single group", () => {
         expect(mapCSSGroups("foo [ bar ]+ baz")).toMatchObject([
             {
@@ -223,7 +223,7 @@ test.describe.only("mapCSSGroups", () => {
     });
 });
 
-test.describe.only("mapMultiplierType", () => {
+test.describe("mapMultiplierType", () => {
     test("should find a zero or more multiplier type", () => {
         expect(mapMultiplierType("foo*")).toMatchObject({
             type: MultiplierType.zeroOrMore,
@@ -257,7 +257,7 @@ test.describe.only("mapMultiplierType", () => {
     });
 });
 
-test.describe.only("mapCombinatorType", () => {
+test.describe("mapCombinatorType", () => {
     test("should find a juxtaposition combination type", () => {
         expect(mapCombinatorType("foo bar bat")).toEqual(CombinatorType.juxtaposition);
         expect(
@@ -291,7 +291,7 @@ test.describe.only("mapCombinatorType", () => {
     });
 });
 
-test.describe.only("resolveReferenceType", () => {
+test.describe("resolveReferenceType", () => {
     test("should resolve a reference of type syntax", () => {
         expect(
             resolveReferenceType("<line-style>", CombinatorType.none, ["line-style"], [])
@@ -320,7 +320,7 @@ test.describe.only("resolveReferenceType", () => {
     });
 });
 
-test.describe.only("resolveCSSPropertySyntaxSplit", () => {
+test.describe("resolveCSSPropertySyntaxSplit", () => {
     test("should split by at least one in any order", () => {
         expect(
             resolveCSSPropertySyntaxSplit(
@@ -357,7 +357,7 @@ test.describe.only("resolveCSSPropertySyntaxSplit", () => {
     });
 });
 
-test.describe.only("resolveCSSGroups", () => {
+test.describe("resolveCSSGroups", () => {
     test("should resolve a simple string referece", () => {
         expect(resolveCSSGroups("<length>", [], [])).toMatchObject([
             {
@@ -474,7 +474,7 @@ test.describe.only("resolveCSSGroups", () => {
     });
 });
 
-test.describe.only("resolveCSSPropertySyntax", () => {
+test.describe("resolveCSSPropertySyntax", () => {
     test("should resolve a CSS properties syntax without shorthand properties", () => {
         expect(
             resolveCSSPropertySyntax(
@@ -567,7 +567,7 @@ test.describe.only("resolveCSSPropertySyntax", () => {
     });
 });
 
-test.describe.only("mapCSSProperties", () => {
+test.describe("mapCSSProperties", () => {
     test("should return a subset of MDN data into a subset of CSS properties ", () => {
         const subsetOfMDNCSS = {
             properties: {
@@ -669,7 +669,7 @@ test.describe.only("mapCSSProperties", () => {
     });
 });
 
-test.describe.only("resolveCSSSyntax", () => {
+test.describe("resolveCSSSyntax", () => {
     test("should resolve a CSS syntax without grouped items", () => {
         expect(resolveCSSSyntax("xx-small | x-small | small", [], [])).toMatchObject({
             ref: [
@@ -736,7 +736,7 @@ test.describe.only("resolveCSSSyntax", () => {
     });
 });
 
-test.describe.only("mapCSSSyntaxes", () => {
+test.describe("mapCSSSyntaxes", () => {
     test("should return a subset of MDN data into a subset of CSS syntaxes", () => {
         const subsetOfMDNCSS = {
             properties: {},
@@ -956,7 +956,7 @@ test.describe.only("mapCSSSyntaxes", () => {
     });
 });
 
-test.describe.only("mapMixedCombinatorTypes", () => {
+test.describe("mapMixedCombinatorTypes", () => {
     test("should add brackets if there are multiple combinator types", () => {
         const syntax1: string = "foo | bar bat";
         expect(mapMixedCombinatorTypes(syntax1)).toEqual("foo | [ bar bat ]");
@@ -998,7 +998,7 @@ test.describe.only("mapMixedCombinatorTypes", () => {
     });
 });
 
-test.describe.only("mapCSSInlineStyleToCSSPropertyDictionary", () => {
+test.describe("mapCSSInlineStyleToCSSPropertyDictionary", () => {
     test("should return an empty dictionary if the style is an empty string", () => {
         expect(mapCSSInlineStyleToCSSPropertyDictionary("")).toMatchObject({});
     });

--- a/packages/design-to-code/src/data-utilities/mapping.spec.pw.ts
+++ b/packages/design-to-code/src/data-utilities/mapping.spec.pw.ts
@@ -11,7 +11,7 @@ import {
 import { DataType, ReservedElementMappingKeyword } from "./types.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-test.describe.only("mapDataDictionary", () => {
+test.describe("mapDataDictionary", () => {
     test("should call a passed mapper and resolver function on a single data dictionary item", () => {
         let mapperCalled = 0;
         let resolverCalled = 0;
@@ -197,7 +197,7 @@ test.describe.only("mapDataDictionary", () => {
     });
 });
 
-test.describe.only("htmlMapper", async () => {
+test.describe("htmlMapper", async () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/utilities");
     });
@@ -1286,7 +1286,7 @@ test.describe.only("htmlMapper", async () => {
     });
 });
 
-test.describe.only("mapWebComponentDefinitionToJSONSchema", () => {
+test.describe("mapWebComponentDefinitionToJSONSchema", () => {
     test("should not throw", () => {
         expect(() => mapWebComponentDefinitionToJSONSchema({ version: 1 })).not.toThrow();
     });

--- a/packages/design-to-code/src/data-utilities/mapping.vscode-html-languageservice.spec.pw.ts
+++ b/packages/design-to-code/src/data-utilities/mapping.vscode-html-languageservice.spec.pw.ts
@@ -62,7 +62,7 @@ const customSchema = {
     },
 };
 
-test.describe.only("mapVSCodeParsedHTMLToDataDictionary", () => {
+test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/utilities");
     });
@@ -664,7 +664,7 @@ test.describe.only("mapVSCodeParsedHTMLToDataDictionary", () => {
     });
 });
 
-test.describe.only("mapVSCodeHTMLAndDataDictionaryToDataDictionary", () => {
+test.describe("mapVSCodeHTMLAndDataDictionaryToDataDictionary", () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/utilities");
     });

--- a/packages/design-to-code/src/data-utilities/monaco.spec.pw.ts
+++ b/packages/design-to-code/src/data-utilities/monaco.spec.pw.ts
@@ -13,7 +13,7 @@ const textSchema = {
     type: DataType.string,
 };
 
-test.describe.only("mapDataDictionaryToMonacoEditorHTML", async () => {
+test.describe("mapDataDictionaryToMonacoEditorHTML", async () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/utilities");
     });
@@ -734,7 +734,7 @@ test.describe.only("mapDataDictionaryToMonacoEditorHTML", async () => {
     });
 });
 
-test.describe.only("findMonacoEditorHTMLPositionByDictionaryId", async () => {
+test.describe("findMonacoEditorHTMLPositionByDictionaryId", async () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/utilities");
     });
@@ -1108,7 +1108,7 @@ test.describe.only("findMonacoEditorHTMLPositionByDictionaryId", async () => {
     });
 });
 
-test.describe.only("findDictionaryIdByMonacoEditorHTMLPosition", async () => {
+test.describe("findDictionaryIdByMonacoEditorHTMLPosition", async () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/utilities");
     });

--- a/packages/design-to-code/src/data-utilities/relocate.spec.pw.ts
+++ b/packages/design-to-code/src/data-utilities/relocate.spec.pw.ts
@@ -10,7 +10,7 @@ import { DataType } from "./types.js";
 /**
  * Gets updated data by adding data to a data blob
  */
-test.describe.only("getDataUpdatedWithSourceData", () => {
+test.describe("getDataUpdatedWithSourceData", () => {
     test("should update an undefined target with source data", () => {
         const data: Dictionary<unknown> = {
             foo: "bar",
@@ -115,7 +115,7 @@ test.describe.only("getDataUpdatedWithSourceData", () => {
 /**
  * Gets updated data by removing data from a data blob
  */
-test.describe.only("getDataUpdatedWithoutSourceData", () => {
+test.describe("getDataUpdatedWithoutSourceData", () => {
     test("should remove source data from an object", () => {
         const data: Dictionary<unknown> = {
             foo: "bar",
@@ -150,7 +150,7 @@ test.describe.only("getDataUpdatedWithoutSourceData", () => {
 /**
  * Gets the next active dictionary ID when linked data is being removed
  */
-test.describe.only("getNextActiveParentDictionaryId", () => {
+test.describe("getNextActiveParentDictionaryId", () => {
     test("should get the current active dictionary ID if the active dictionary ID is not being removed", () => {
         expect(
             getNextActiveParentDictionaryId(

--- a/packages/design-to-code/src/message-system-service/ajv-validation.service.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/ajv-validation.service.spec.pw.ts
@@ -17,7 +17,7 @@ import { DataType } from "../data-utilities/types.js";
 import { AjvMapper, ajvValidationId } from "./ajv-validation.service.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-test.describe.only("AjvMapper", () => {
+test.describe("AjvMapper", () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/message-system");
     });

--- a/packages/design-to-code/src/message-system-service/monaco-adapter.service-action.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/monaco-adapter.service-action.spec.pw.ts
@@ -3,7 +3,7 @@ import { MessageSystemType } from "../message-system/index.js";
 import { MonacoAdapterAction } from "./monaco-adapter.service-action.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-test.describe.only("MonacoAdapterAction", () => {
+test.describe("MonacoAdapterAction", () => {
     test("should not throw", () => {
         expect(() => {
             new MonacoAdapterAction({

--- a/packages/design-to-code/src/message-system-service/monaco-adapter.service.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/monaco-adapter.service.spec.pw.ts
@@ -7,7 +7,7 @@ import {
 } from "./monaco-adapter.service.utilities.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-test.describe.only("MonacoAdapter", async () => {
+test.describe("MonacoAdapter", async () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/message-system");
     });
@@ -958,7 +958,7 @@ test.describe.only("MonacoAdapter", async () => {
     });
 });
 
-test.describe.only("findDictionaryIdParents", () => {
+test.describe("findDictionaryIdParents", () => {
     test("should not return any parents if this is the root dictionary item", () => {
         expect(
             findDictionaryIdParents("root", [
@@ -1073,7 +1073,7 @@ test.describe.only("findDictionaryIdParents", () => {
     });
 });
 
-test.describe.only("findUpdatedDictionaryId", () => {
+test.describe("findUpdatedDictionaryId", () => {
     test("should return the root dictionary id if there is no parent items", () => {
         expect(
             findUpdatedDictionaryId(

--- a/packages/design-to-code/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.delete.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.delete.spec.pw.ts
@@ -7,7 +7,7 @@ import {
 import { MessageSystemType } from "../../message-system/types.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-test.describe.only("ShortcutsActionDelete", async () => {
+test.describe("ShortcutsActionDelete", async () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/message-system");
     });

--- a/packages/design-to-code/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.duplicate.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.duplicate.spec.pw.ts
@@ -7,7 +7,7 @@ import {
 import { MessageSystemType } from "../../message-system/types.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-test.describe.only("ShortcutsActionDuplicate", async () => {
+test.describe("ShortcutsActionDuplicate", async () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/message-system");
     });

--- a/packages/design-to-code/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.redo.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.redo.spec.pw.ts
@@ -7,7 +7,7 @@ import {
 import { MessageSystemType } from "../../message-system/types.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-test.describe.only("ShortcutsActionRedo", () => {
+test.describe("ShortcutsActionRedo", () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/message-system");
     });

--- a/packages/design-to-code/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.undo.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.undo.spec.pw.ts
@@ -8,7 +8,7 @@ import {
 import { MessageSystemType } from "../../message-system/types.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-test.describe.only("ShortcutsActionUndo", () => {
+test.describe("ShortcutsActionUndo", () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/message-system");
     });

--- a/packages/design-to-code/src/message-system-service/shortcuts.service-action.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/shortcuts.service-action.spec.pw.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import { ShortcutsAction } from "./shortcuts.service-action.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-test.describe.only("ShortcutsAction", () => {
+test.describe("ShortcutsAction", () => {
     test("should not throw", () => {
         expect(() => {
             new ShortcutsAction({

--- a/packages/design-to-code/src/message-system-service/shortcuts.service.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/shortcuts.service.spec.pw.ts
@@ -3,7 +3,7 @@ import { MessageSystemType, Register } from "../message-system/index.js";
 import { ShortcutsConfig, shortcutsId } from "./shortcuts.service.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-test.describe.only("Shortcuts", async () => {
+test.describe("Shortcuts", async () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/message-system");
     });

--- a/packages/design-to-code/src/message-system/data.spec.pw.ts
+++ b/packages/design-to-code/src/message-system/data.spec.pw.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import { getLinkedData, getLinkedDataDictionary, getLinkedDataList } from "./data.js";
 import { Data, LinkedDataPromise } from "./data.props.js";
 
-test.describe.only("getLinkedDataDictionary", () => {
+test.describe("getLinkedDataDictionary", () => {
     test("should get a linked data dictionary", () => {
         const dictionaryId: string = "root";
         const dataLocation: string = "foo";
@@ -127,7 +127,7 @@ test.describe.only("getLinkedDataDictionary", () => {
     });
 });
 
-test.describe.only("getLinkedData", () => {
+test.describe("getLinkedData", () => {
     test("should get a linked data set", () => {
         expect(
             getLinkedData(
@@ -201,7 +201,7 @@ test.describe.only("getLinkedData", () => {
     });
 });
 
-test.describe.only("getLinkedDataList", () => {
+test.describe("getLinkedDataList", () => {
     test("should get an empty list if an item does not contain linked data", () => {
         expect(
             getLinkedDataList(

--- a/packages/design-to-code/src/message-system/message-system.spec.pw.ts
+++ b/packages/design-to-code/src/message-system/message-system.spec.pw.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import type { Register } from "./message-system.props.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-test.describe.only("MessageSystem", async () => {
+test.describe("MessageSystem", async () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/message-system");
     });

--- a/packages/design-to-code/src/message-system/message-system.utilities.spec.pw.ts
+++ b/packages/design-to-code/src/message-system/message-system.utilities.spec.pw.ts
@@ -33,7 +33,7 @@ import { SchemaDictionary } from "./schema.props.js";
 import { getNavigationDictionary } from "./navigation.js";
 import { removeRootDataNodeErrorMessage } from "./errors.js";
 
-test.describe.only("getMessage", () => {
+test.describe("getMessage", () => {
     test.describe("history", () => {
         test("should return messages sent to get the history", () => {
             const getHistory: InternalIncomingMessage<GetHistoryMessageIncoming> = [

--- a/packages/design-to-code/src/message-system/navigation.spec.pw.ts
+++ b/packages/design-to-code/src/message-system/navigation.spec.pw.ts
@@ -8,7 +8,7 @@ import { TreeNavigationItem } from "./navigation.props.js";
 /**
  * Gets the navigation
  */
-test.describe.only("getNavigation", () => {
+test.describe("getNavigation", () => {
     test("should get a single navigation object from a schema with type object", () => {
         expect(
             getNavigation({
@@ -699,7 +699,7 @@ test.describe.only("getNavigation", () => {
     });
 });
 
-test.describe.only("getNavigationDictionary", () => {
+test.describe("getNavigationDictionary", () => {
     test("should not throw", () => {
         expect(() =>
             getNavigationDictionary(

--- a/packages/design-to-code/src/schemas/linked-data.schema.spec.pw.ts
+++ b/packages/design-to-code/src/schemas/linked-data.schema.spec.pw.ts
@@ -5,7 +5,7 @@ import { linkedDataSchema } from "./index.js";
 const validator: ajv.Ajv = new ajv({ schemaId: "auto", allErrors: true });
 const validationFn: ajv.ValidateFunction = validator.compile(linkedDataSchema);
 
-test.describe.only("linked data schema", () => {
+test.describe("linked data schema", () => {
     test("should be valid against an array of linked data corresponding to the linekd data schema", () => {
         expect(validationFn([{ id: "foo" }])).toEqual(true);
     });

--- a/packages/design-to-code/src/web-components/color-picker/color-picker.spec.pw.ts
+++ b/packages/design-to-code/src/web-components/color-picker/color-picker.spec.pw.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test.describe.only("Color Picker", () => {
+test.describe("Color Picker", () => {
     test.beforeEach(async ({ page }) => {
         // Playwright is configured to use http://localhost:7001 as the base URL for all tests
         // so you can use a relative URL to navigate to a different page.

--- a/packages/design-to-code/src/web-components/css-box-model/css-box-model.spec.pw.ts
+++ b/packages/design-to-code/src/web-components/css-box-model/css-box-model.spec.pw.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test.describe.only("CSS Box Model", () => {
+test.describe("CSS Box Model", () => {
     test.beforeEach(async ({ page }) => {
         // Playwright is configured to use http://localhost:7001 as the base URL for all tests
         // so you can use a relative URL to navigate to a different page.

--- a/packages/design-to-code/src/web-components/css-layout/css-layout.spec.pw.ts
+++ b/packages/design-to-code/src/web-components/css-layout/css-layout.spec.pw.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test.describe.only("CSSLayout", () => {
+test.describe("CSSLayout", () => {
     test.beforeEach(async ({ page }) => {
         // Playwright is configured to use http://localhost:7001 as the base URL for all tests
         // so you can use a relative URL to navigate to a different page.

--- a/packages/design-to-code/src/web-components/file/file.spec.pw.ts
+++ b/packages/design-to-code/src/web-components/file/file.spec.pw.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { DTCFile } from "./file.define.js";
 
-test.describe.only("File", () => {
+test.describe("File", () => {
     test.beforeEach(async ({ page }) => {
         // Playwright is configured to use http://localhost:7001 as the base URL for all tests
         // so you can use a relative URL to navigate to a different page.

--- a/packages/design-to-code/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.spec.pw.ts
+++ b/packages/design-to-code/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.spec.pw.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { getMessage, getMessageAll } from "../html-render/__tests__/helpers.js";
 
-test.describe.only("HTML Render Layer Inline Edit", () => {
+test.describe("HTML Render Layer Inline Edit", () => {
     test.beforeEach(async ({ page }) => {
         // Playwright is configured to use http://localhost:7001 as the base URL for all tests
         // so you can use a relative URL to navigate to a different page.

--- a/packages/design-to-code/src/web-components/html-render-layer-navigation/html-render-layer-navigation.spec.pw.ts
+++ b/packages/design-to-code/src/web-components/html-render-layer-navigation/html-render-layer-navigation.spec.pw.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { getMessageAll } from "../html-render/__tests__/helpers.js";
 
-test.describe.only("HTML Render Layer Navigation", () => {
+test.describe("HTML Render Layer Navigation", () => {
     test.beforeEach(async ({ page }) => {
         // Playwright is configured to use http://localhost:7001 as the base URL for all tests
         // so you can use a relative URL to navigate to a different page.

--- a/packages/design-to-code/src/web-components/html-render/html-render.spec.pw.ts
+++ b/packages/design-to-code/src/web-components/html-render/html-render.spec.pw.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { getMessage, getMessageAll } from "./__tests__/helpers.js";
 
-test.describe.only("HTML Render", () => {
+test.describe("HTML Render", () => {
     test.beforeEach(async ({ page }) => {
         // Playwright is configured to use http://localhost:7001 as the base URL for all tests
         // so you can use a relative URL to navigate to a different page.

--- a/packages/design-to-code/src/web-components/units-text-field/units-text-field.spec.pw.ts
+++ b/packages/design-to-code/src/web-components/units-text-field/units-text-field.spec.pw.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { DTCUnitsTextField } from "./units-text-field.define.js";
 
-test.describe.only("Units text-field", () => {
+test.describe("Units text-field", () => {
     test.beforeEach(async ({ page }) => {
         // Playwright is configured to use http://localhost:7001 as the base URL for all tests
         // so you can use a relative URL to navigate to a different page.


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change removes some temporary measures for testing that, now that all tests are converted to playwright and re-integrated, are not necessary.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
