### PR TITLE
Added preview readiness check before initializing

### DIFF
--- a/app/shared/constants.ts
+++ b/app/shared/constants.ts
@@ -12,3 +12,8 @@ export const initialDataDictionary: DataDictionary<unknown> = [
 ];
 
 export const initialSchemaDictionary: SchemaDictionary = nativeElementSchemaDictionary;
+
+export const requestPreviewInitialize: string = "PREVIEW:INITIALIZE";
+
+export const originatedByPreview: string = "design-to-code::preview";
+export const originatedByEditor: string = "design-to-code::editor";

--- a/app/src/components/monaco-editor.tsx
+++ b/app/src/components/monaco-editor.tsx
@@ -1,13 +1,13 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { MessageSystem, MonacoAdapter, monacoAdapterId } from "design-to-code";
 import { mapDataDictionaryToMonacoEditorHTML } from "design-to-code/dist/esm/data-utilities/monaco";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import { html_beautify } from "vscode-html-languageservice/lib/esm/beautify/beautify-html";
 import { setValueAction } from "./monaco-editor.actions";
+import { originatedByPreview } from "../../shared/constants";
 
 export interface MonacoEditorProps {
     messageSystem: MessageSystem;
-    initialValue: string;
 }
 
 /**
@@ -26,11 +26,10 @@ function createMonacoAdapter(messageSystem: MessageSystem, editor): MonacoAdapte
 function createMonacoEditor(
     monacoRef,
     containerRef: React.MutableRefObject<unknown>,
-    editorOptions,
-    initialValue: string
+    editorOptions
 ) {
     return monacoRef.editor.create(containerRef, {
-        value: initialValue,
+        value: "",
         automaticLayout: true,
         language: "html",
         formatOnPaste: true,
@@ -48,20 +47,39 @@ function createMonacoEditor(
 }
 
 export function MonacoEditor(props: MonacoEditorProps) {
-    let editor;
-    props.messageSystem.add({ onMessage: handleMessageSystem });
+    let editor = null;
+    let editorNode = null;
+    let adapter = null;
 
-    const [lastStoredEditorValue, setLastStoredEditorValue] = useState(
-        props.initialValue
-    );
+    const [lastStoredEditorValue, setLastStoredEditorValue] = useState("");
+    const [initialized, setInitialized] = useState(false);
 
     const onRefChange = useCallback(node => {
         if (node !== null) {
-            editor = createMonacoEditor(monaco, node, {}, "");
-            const adapter = createMonacoAdapter(props.messageSystem, editor);
-            setupMonacoListeners(editor, adapter);
+            editorNode = node;
         }
     }, []);
+
+    useEffect(() => {
+        if (editorNode && !initialized) {
+            setInitialized(true);
+            props.messageSystem.add({ onMessage: handleMessageSystem });
+            editor = createMonacoEditor(monaco, editorNode, {});
+            adapter = createMonacoAdapter(props.messageSystem, editor);
+            setupMonacoListeners(editor, adapter);
+        }
+
+        return () => {
+            if (initialized) {
+                setInitialized(false);
+                props.messageSystem.remove({
+                    onMessage: handleMessageSystem,
+                });
+                editor.dispose();
+                adapter.destroy();
+            }
+        };
+    }, [initialized]);
 
     function setupMonacoListeners(editor, adapter) {
         editor.onDidChangeModelContent(e => {
@@ -73,10 +91,10 @@ export function MonacoEditor(props: MonacoEditorProps) {
     }
 
     function handleMessageSystem(e: MessageEvent) {
-        if (editor) {
+        if (editor && e.data.options?.originatorId !== originatedByPreview) {
             if (e.data.options?.originatorId === monacoAdapterId) {
                 setLastStoredEditorValue(editor.getValue());
-            } else {
+            } else if (e.data.options?.originatorId !== originatedByPreview) {
                 const newMonacoValue = html_beautify(
                     mapDataDictionaryToMonacoEditorHTML(
                         e.data.dataDictionary,

--- a/packages/design-to-code/src/message-system-service/monaco-adapter.service.ts
+++ b/packages/design-to-code/src/message-system-service/monaco-adapter.service.ts
@@ -56,22 +56,27 @@ export class MonacoAdapter extends MessageSystemService<
      * Handles messages from the message system
      */
     handleMessageSystem = (e: MessageEvent): void => {
-        this.dictionaryId = e.data.activeDictionaryId;
-        this.dataDictionary = e.data.dataDictionary;
-        this.schemaDictionary = e.data.schemaDictionary;
+        if (
+            e.data.type !== MessageSystemType.custom &&
+            e.data.options?.originatorId !== monacoAdapterId
+        ) {
+            this.dictionaryId = e.data.activeDictionaryId;
+            this.dataDictionary = e.data.dataDictionary;
+            this.schemaDictionary = e.data.schemaDictionary;
 
-        if (e.data.options?.originatorId !== monacoAdapterId) {
-            this.monacoModelValue = [
-                mapDataDictionaryToMonacoEditorHTML(
-                    e.data.dataDictionary,
-                    e.data.schemaDictionary
-                ),
-            ];
-            this.registeredActions.forEach((action: MonacoAdapterAction) => {
-                if (action.matches(e.data.type)) {
-                    action.invoke();
-                }
-            });
+            if (e.data.options?.originatorId !== monacoAdapterId) {
+                this.monacoModelValue = [
+                    mapDataDictionaryToMonacoEditorHTML(
+                        e.data.dataDictionary,
+                        e.data.schemaDictionary
+                    ),
+                ];
+                this.registeredActions.forEach((action: MonacoAdapterAction) => {
+                    if (action.matches(e.data.type)) {
+                        action.invoke();
+                    }
+                });
+            }
         }
     };
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This pull request checks for the preview to be ready before sending an initialization message. There is a residual issue in the app where the messages are not synced, and the monaco adaptor sends initialization messages that are unnecessary when the monaco adaptor is not doing the updates. This will be addressed in a later code update.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.