### PR TITLE
Disallow mousewheel scroll from affecting the numberfield control

### DIFF
--- a/packages/design-to-code-react/src/form/controls/control.number-field.tsx
+++ b/packages/design-to-code-react/src/form/controls/control.number-field.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { NumberFieldControlProps } from "./control.number-field.props";
 import { classNames } from "@microsoft/fast-web-utilities";
 import { isDefault } from "./utilities/form";
@@ -19,6 +19,7 @@ style;
  */
 function NumberFieldControl(props: NumberFieldControlProps) {
     let hasFocus: boolean = false;
+    let ref = useRef(0);
 
     function handleFocus(callback: () => void) {
         return (): void => {
@@ -57,6 +58,29 @@ function NumberFieldControl(props: NumberFieldControlProps) {
             : "";
     }
 
+    function handleWheel(e: WheelEvent): void {
+        e.preventDefault();
+    }
+
+    useEffect(() => {
+        if (props.elementRef.current) {
+            (props.elementRef.current as HTMLInputElement).addEventListener(
+                "wheel",
+                handleWheel,
+                { passive: false }
+            );
+        }
+
+        return function cancel() {
+            if (props.elementRef.current) {
+                (props.elementRef.current as HTMLInputElement).removeEventListener(
+                    "wheel",
+                    handleWheel
+                );
+            }
+        };
+    });
+
     return (
         <input
             className={classNames(
@@ -76,7 +100,7 @@ function NumberFieldControl(props: NumberFieldControlProps) {
             max={props.max}
             step={props.step}
             disabled={props.disabled}
-            ref={props.elementRef as React.Ref<HTMLInputElement>}
+            ref={props.elementRef}
             onBlur={handleBlur(props.updateValidity)}
             onFocus={handleFocus(props.reportValidity)}
             required={props.required}

--- a/packages/design-to-code-react/src/form/controls/control.textarea.tsx
+++ b/packages/design-to-code-react/src/form/controls/control.textarea.tsx
@@ -64,7 +64,7 @@ function TextareaControl(props: TextareaControlProps) {
             value={getValue()}
             onChange={handleChange()}
             disabled={props.disabled}
-            ref={props.elementRef as React.Ref<HTMLTextAreaElement>}
+            ref={props.elementRef as React.MutableRefObject<HTMLTextAreaElement>}
             onFocus={handleFocus}
             onBlur={handleBlur}
             required={props.required}

--- a/packages/design-to-code-react/src/form/templates/template.control.bare.tsx
+++ b/packages/design-to-code-react/src/form/templates/template.control.bare.tsx
@@ -8,7 +8,7 @@ import { FormHTMLElement } from "./template.control.utilities.props";
  * Control template definition
  */
 function BareControlTemplate(props: BareControlTemplateProps) {
-    const ref: React.RefObject<FormHTMLElement> = React.createRef<FormHTMLElement>();
+    const ref: React.MutableRefObject<null> = React.createRef<null>();
     let cache: any = undefined;
 
     function setCache(updatedCache: any): void {

--- a/packages/design-to-code-react/src/form/templates/template.control.single-line.tsx
+++ b/packages/design-to-code-react/src/form/templates/template.control.single-line.tsx
@@ -37,7 +37,7 @@ style;
  * Control template definition
  */
 function SingleLineControlTemplate(props: SingleLineControlTemplateProps) {
-    const ref: React.RefObject<FormHTMLElement> = React.createRef<FormHTMLElement>();
+    const ref: React.MutableRefObject<null> = React.createRef<null>();
     let cache: any = undefined;
 
     function setCache(updatedCache: any): void {

--- a/packages/design-to-code-react/src/form/templates/template.control.standard.tsx
+++ b/packages/design-to-code-react/src/form/templates/template.control.standard.tsx
@@ -45,7 +45,7 @@ style;
  * Control template definition
  */
 function StandardControlTemplate(props: StandardControlTemplateProps) {
-    const ref: React.RefObject<FormHTMLElement> = React.createRef<FormHTMLElement>();
+    const ref: React.MutableRefObject<null> = React.createRef<null>();
     let cache: any = undefined;
 
     function setCache(updatedCache: any): void {

--- a/packages/design-to-code-react/src/form/templates/template.control.utilities.props.tsx
+++ b/packages/design-to-code-react/src/form/templates/template.control.utilities.props.tsx
@@ -250,7 +250,7 @@ export interface CommonControlConfig {
     /**
      * The ref belonging to the form element injected as part of the control
      */
-    elementRef: React.Ref<FormHTMLElement>;
+    elementRef: React.MutableRefObject<null>;
 
     /**
      * The invalid error object

--- a/packages/design-to-code-react/src/form/templates/template.control.utilities.tsx
+++ b/packages/design-to-code-react/src/form/templates/template.control.utilities.tsx
@@ -220,7 +220,7 @@ export function renderInvalidMessage(props: RenderInvalidMessageProps): React.Re
 }
 
 export interface UpdateValidityProps {
-    ref: React.RefObject<FormHTMLElement>;
+    ref: React.MutableRefObject<FormHTMLElement>;
     invalidMessage: string;
 }
 
@@ -243,7 +243,7 @@ export function updateValidity(props: UpdateValidityProps): () => void {
 }
 
 export interface ReportValidityProps {
-    ref: React.RefObject<FormHTMLElement>;
+    ref: React.MutableRefObject<FormHTMLElement>;
     invalidMessage: string;
     displayValidationBrowserDefault?: boolean;
 }
@@ -275,7 +275,7 @@ export interface GetConfigProps extends ControlTemplateUtilitiesProps {
     /**
      * The form element React ref
      */
-    ref: React.RefObject<FormHTMLElement>;
+    ref: React.MutableRefObject<null>;
 }
 
 export function getConfig(props: GetConfigProps): ControlConfig {


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
React adds change events to inputs with type number that is triggered on scrolling. Since this is not native to input elements we will override it.

closes #114

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
