### PR TITLE
Add the ability to resolve definition fragment URIs when generating example data

### DIFF
--- a/packages/design-to-code/src/data-utilities/generate.spec.pw.ts
+++ b/packages/design-to-code/src/data-utilities/generate.spec.pw.ts
@@ -333,4 +333,26 @@ test.describe("getDataFromSchema", () => {
             bar: true,
         });
     });
+    test("should return data when the schema references a definition", () => {
+        const schemaWithDefinition: any = {
+            $schema: "http://json-schema.org/schema#",
+            $id: "https://example.com/schemas/customer",
+            id: "definitions",
+            title: "A schema with definitions",
+            type: "object",
+            properties: {
+                a: { $ref: "#/$defs/name" },
+                b: { $ref: "#/$defs/name" },
+            },
+            required: ["a", "b"],
+            $defs: {
+                name: { type: "string" },
+            },
+        };
+
+        expect(getDataFromSchema(schemaWithDefinition)).toMatchObject({
+            a: "example text",
+            b: "example text",
+        });
+    });
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change uses the new dot notation conversion utility to resolve a URI fragment when generating example data.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Continued work on #111

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Resolve `$defs` in the `Form` component