### PR TITLE
Add the ability to reference URI fragments pointing to the schemas

### DIFF
--- a/packages/design-to-code-react/app/pages/form/index.ts
+++ b/packages/design-to-code-react/app/pages/form/index.ts
@@ -16,6 +16,7 @@ import {
     controlPluginCssWithOverridesSchema,
     controlPluginSchema as customControlSchema,
     defaultsSchema,
+    definitionsSchema,
     dictionarySchema,
     disabledSchema,
     generalSchema,
@@ -46,6 +47,10 @@ export const controlPluginCssWithOverrides: ExampleComponent = {
 
 export const controlPluginCss: ExampleComponent = {
     schema: controlPluginCssSchema,
+};
+
+export const definitions: ExampleComponent = {
+    schema: definitionsSchema,
 };
 
 export const textField: ExampleComponent = {

--- a/packages/design-to-code-react/src/__tests__/schemas/definitions.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/definitions.schema.ts
@@ -1,0 +1,14 @@
+export default {
+    $schema: "http://json-schema.org/schema#",
+    id: "definitions",
+    title: "A schema with definitions",
+    type: "object",
+    properties: {
+        a: { $ref: "#/$defs/text" },
+        b: { $ref: "#/$defs/text" },
+    },
+    required: ["a", "b"],
+    $defs: {
+        text: { type: "string" },
+    },
+};

--- a/packages/design-to-code-react/src/__tests__/schemas/index.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/index.ts
@@ -13,6 +13,7 @@ import controlPluginSchema from "./control-plugin.schema";
 import controlPluginCssWithOverridesSchema from "./control-plugin.css-with-overrides.schema";
 import controlPluginCssSchema from "./control-plugin.css.schema";
 import defaultsSchema from "./defaults.schema";
+import definitionsSchema from "./definitions.schema";
 import dictionarySchema from "./dictionary.schema";
 import disabledSchema from "./disabled.schema";
 import generalExampleSchema from "./general-example.schema";
@@ -46,6 +47,7 @@ export {
     controlPluginCssWithOverridesSchema,
     controlPluginCssSchema,
     defaultsSchema,
+    definitionsSchema,
     dictionarySchema,
     disabledSchema,
     generalExampleSchema,

--- a/packages/design-to-code-react/src/form/controls/utilities/control-switch.tsx
+++ b/packages/design-to-code-react/src/form/controls/utilities/control-switch.tsx
@@ -13,7 +13,7 @@ import ControlPluginUtilities, {
     ControlPluginUtilitiesProps,
 } from "../../templates/plugin.control.utilities";
 import { ControlType } from "../../index";
-import { dictionaryLink } from "design-to-code";
+import { dictionaryLink, normalizeURIToDotNotation } from "design-to-code";
 import { XOR } from "design-to-code/dist/dts/data-utilities/type.utilities";
 
 function ControlSwitch(props: ControlSwitchProps) {
@@ -21,6 +21,21 @@ function ControlSwitch(props: ControlSwitchProps) {
      * Renders form items
      */
     function renderControl(): React.ReactNode {
+        // Check to see if this is a reference
+        if (typeof props.schema.$ref === "string") {
+            return (
+                <ControlSwitch
+                    {...props}
+                    schema={get(
+                        props.schemaDictionary[
+                            props.dataDictionary[0][props.dataDictionary[1]].schemaId
+                        ],
+                        normalizeURIToDotNotation(props.schema.$ref)
+                    )}
+                />
+            );
+        }
+
         let control: ControlPluginUtilities<ControlPluginUtilitiesProps>;
 
         // Check to see if there is any associated `controlId`


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
Add the ability to reference URI fragments pointing to the schemas - works on a single schema but does not currently reference any other schemas provided.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
closes #111

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- File issues for:
    - Completing the ability for `$ref` to reference any schema and any pattern as specified in JSON schema spec