### PR TITLE
Update the schemas to use the  property instead of id, invalidating Draft 4 specification, this is noted on support markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is the Design to Code project, containing a set of packages that can be combined to create complex workflows. The goal of these workflows is to allow users to create and modify their own web based experiences, from individual web components to completed web sites.
 
+Check out our [documentation site](https://janechu.github.io/design-to-code/) to get started.
+
 ## Packages
 
 ### `design-to-code`

--- a/docs-files/sidebar.js
+++ b/docs-files/sidebar.js
@@ -14,6 +14,11 @@ module.exports = {
             path: "introduction",
         },
         {
+            type: "doc",
+            label: "Supported formats",
+            path: "support",
+        },
+        {
             type: "category",
             label: "Message System",
             description:

--- a/docs-files/support.md
+++ b/docs-files/support.md
@@ -1,0 +1,7 @@
+# Support
+
+## JSON schema
+
+[Draft 2020-12](https://json-schema.org/draft/2020-12/schema)
+
+The project may support earlier JSON schema specifications but this would be incidental and may break in the future.

--- a/packages/design-to-code-react/app/pages/form-and-navigation.tsx
+++ b/packages/design-to-code-react/app/pages/form-and-navigation.tsx
@@ -60,7 +60,7 @@ class FormAndNavigationTestPage extends React.Component<{}, FormTestPageState> {
                 dataDictionary: [
                     {
                         "": {
-                            schemaId: testConfigs.textField.schema.id,
+                            schemaId: testConfigs.textField.schema.$id,
                             data: exampleData,
                         },
                     },
@@ -77,7 +77,7 @@ class FormAndNavigationTestPage extends React.Component<{}, FormTestPageState> {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: testConfigs.textField.schema.id,
+                        schemaId: testConfigs.textField.schema.$id,
                         data: exampleData,
                     },
                 },
@@ -170,7 +170,7 @@ class FormAndNavigationTestPage extends React.Component<{}, FormTestPageState> {
         const schemaDictionary: SchemaDictionary = {};
 
         Object.keys(testConfigs).forEach((testConfigKey: string) => {
-            schemaDictionary[testConfigs[testConfigKey].schema.id] =
+            schemaDictionary[testConfigs[testConfigKey].schema.$id] =
                 testConfigs[testConfigKey].schema;
         });
 
@@ -287,7 +287,7 @@ class FormAndNavigationTestPage extends React.Component<{}, FormTestPageState> {
                 data: [
                     {
                         "": {
-                            schemaId: testConfigs[e.target.value].schema.id,
+                            schemaId: testConfigs[e.target.value].schema.$id,
                             data,
                         },
                     },
@@ -300,7 +300,9 @@ class FormAndNavigationTestPage extends React.Component<{}, FormTestPageState> {
 
     private getComponentOptions(): JSX.Element[] {
         return Object.keys(testConfigs).map((testComponentKey: any, index: number) => {
-            return <option key={index}>{testConfigs[testComponentKey].schema.id}</option>;
+            return (
+                <option key={index}>{testConfigs[testComponentKey].schema.$id}</option>
+            );
         });
     }
 }

--- a/packages/design-to-code-react/app/pages/form.tsx
+++ b/packages/design-to-code-react/app/pages/form.tsx
@@ -252,7 +252,7 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
                 dataDictionary: [
                     {
                         foo: {
-                            schemaId: testConfigs.controlPluginCss.schema.id,
+                            schemaId: testConfigs.controlPluginCss.schema.$id,
                             data: exampleData,
                         },
                     },
@@ -272,7 +272,7 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
             dataDictionary: [
                 {
                     foo: {
-                        schemaId: testConfigs.controlPluginCss.schema.id,
+                        schemaId: testConfigs.controlPluginCss.schema.$id,
                         data: exampleData,
                     },
                 },
@@ -309,7 +309,7 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
                     <div>
                         <select
                             onChange={this.handleComponentUpdate}
-                            defaultValue={testConfigs.controlPluginCss.schema.id}
+                            defaultValue={testConfigs.controlPluginCss.schema.$id}
                         >
                             {this.getComponentOptions()}
                         </select>
@@ -365,7 +365,7 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
     }
 
     private renderDataSetComponentOptions(): React.ReactNode {
-        if (this.state.schema.id === testConfigs.allControlTypes.schema.id) {
+        if (this.state.schema.$id === testConfigs.allControlTypes.schema.$id) {
             return (
                 <select onChange={this.handleDataSetUpdate}>
                     {this.getComponentDataSets()}
@@ -378,7 +378,7 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
         const schemaDictionary: SchemaDictionary = {};
 
         Object.keys(testConfigs).forEach((testConfigKey: string) => {
-            schemaDictionary[testConfigs[testConfigKey].schema.id] =
+            schemaDictionary[testConfigs[testConfigKey].schema.$id] =
                 testConfigs[testConfigKey].schema;
         });
 
@@ -528,8 +528,8 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
     private handleComponentUpdate = (e: React.ChangeEvent<HTMLSelectElement>): void => {
         const data: any = !!testConfigs[e.target.value].data
             ? testConfigs[e.target.value].data
-            : testConfigs[e.target.value].schema.id ===
-              testConfigs.allControlTypes.schema.id
+            : testConfigs[e.target.value].schema.$id ===
+              testConfigs.allControlTypes.schema.$id
             ? this.state.dataSet
             : getDataFromSchema(testConfigs[e.target.value].schema);
 
@@ -539,7 +539,7 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
                 data: [
                     {
                         foo: {
-                            schemaId: testConfigs[e.target.value].schema.id,
+                            schemaId: testConfigs[e.target.value].schema.$id,
                             data,
                         },
                     },
@@ -552,7 +552,9 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
 
     private getComponentOptions(): JSX.Element[] {
         return Object.keys(testConfigs).map((testComponentKey: any, index: number) => {
-            return <option key={index}>{testConfigs[testComponentKey].schema.id}</option>;
+            return (
+                <option key={index}>{testConfigs[testComponentKey].schema.$id}</option>
+            );
         });
     }
 }

--- a/packages/design-to-code-react/app/pages/navigation.tsx
+++ b/packages/design-to-code-react/app/pages/navigation.tsx
@@ -27,8 +27,8 @@ class NavigationTestPage extends React.Component<{}, NavigationTestPageState> {
                 webWorker: "message-system.js",
                 dataDictionary: children,
                 schemaDictionary: {
-                    [childrenSchema.id]: childrenSchema,
-                    [noChildrenSchema.id]: noChildrenSchema,
+                    [childrenSchema.$id]: childrenSchema,
+                    [noChildrenSchema.$id]: noChildrenSchema,
                 },
             });
         }
@@ -203,8 +203,8 @@ class NavigationTestPage extends React.Component<{}, NavigationTestPageState> {
 
     private handleSetDefaultLinkedDataDatalocation = (e: React.ChangeEvent): void => {
         this.setState({
-            defaultLinkedDataDroppableDataLocation: !this.state
-                .defaultLinkedDataDroppableDataLocation,
+            defaultLinkedDataDroppableDataLocation:
+                !this.state.defaultLinkedDataDroppableDataLocation,
         });
     };
 

--- a/packages/design-to-code-react/app/pages/navigation/example.data.ts
+++ b/packages/design-to-code-react/app/pages/navigation/example.data.ts
@@ -8,7 +8,7 @@ const noChildren: any = {
 const children: DataDictionary<any> = [
     {
         foo: {
-            schemaId: childrenSchema.id,
+            schemaId: childrenSchema.$id,
             data: {
                 children: [
                     {
@@ -28,7 +28,7 @@ const children: DataDictionary<any> = [
                 id: "foo",
                 dataLocation: "children",
             },
-            schemaId: noChildrenSchema.id,
+            schemaId: noChildrenSchema.$id,
             data: {
                 text: "bar",
             },
@@ -38,7 +38,7 @@ const children: DataDictionary<any> = [
                 id: "foo",
                 dataLocation: "children",
             },
-            schemaId: noChildrenSchema.id,
+            schemaId: noChildrenSchema.$id,
             data: {
                 text: "bat",
             },
@@ -48,7 +48,7 @@ const children: DataDictionary<any> = [
                 id: "foo",
                 dataLocation: "children",
             },
-            schemaId: childrenSchema.id,
+            schemaId: childrenSchema.$id,
             data: {
                 children: [
                     {
@@ -62,7 +62,7 @@ const children: DataDictionary<any> = [
                 id: "baz",
                 dataLocation: "children",
             },
-            schemaId: noChildrenSchema.id,
+            schemaId: noChildrenSchema.$id,
             data: {},
         },
     },

--- a/packages/design-to-code-react/app/pages/web-components.tsx
+++ b/packages/design-to-code-react/app/pages/web-components.tsx
@@ -44,7 +44,7 @@ class WebComponentTestPage extends React.Component<{}, WebComponentTestPageState
                 dataDictionary: [
                     {
                         foo: {
-                            schemaId: fancyButtonSchema.id,
+                            schemaId: fancyButtonSchema.$id,
                             data: {},
                         },
                     },
@@ -126,7 +126,7 @@ class WebComponentTestPage extends React.Component<{}, WebComponentTestPageState
         const schemaDictionary: SchemaDictionary = {};
 
         Object.keys(webComponentSchemas).forEach((webComponentSchemasKey: string) => {
-            schemaDictionary[webComponentSchemas[webComponentSchemasKey].schema.id] =
+            schemaDictionary[webComponentSchemas[webComponentSchemasKey].schema.$id] =
                 webComponentSchemas[webComponentSchemasKey].schema;
         });
 
@@ -184,7 +184,7 @@ class WebComponentTestPage extends React.Component<{}, WebComponentTestPageState
                 data: [
                     {
                         foo: {
-                            schemaId: webComponentSchemas[e.target.value].schema.id,
+                            schemaId: webComponentSchemas[e.target.value].schema.$id,
                             data,
                         },
                     },
@@ -200,7 +200,7 @@ class WebComponentTestPage extends React.Component<{}, WebComponentTestPageState
             (webComponentSchemasKey: any, index: number) => {
                 return (
                     <option key={index}>
-                        {webComponentSchemas[webComponentSchemasKey].schema.id}
+                        {webComponentSchemas[webComponentSchemasKey].schema.$id}
                     </option>
                 );
             }

--- a/packages/design-to-code-react/app/pages/web-components/fancy-button.schema.ts
+++ b/packages/design-to-code-react/app/pages/web-components/fancy-button.schema.ts
@@ -2,11 +2,11 @@ import { linkedDataSchema, ReservedElementMappingKeyword } from "design-to-code"
 
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "fancyButton",
     title: "Fancy button",
     [ReservedElementMappingKeyword.mapsToTagName]: "fancy-button",
     description: "A test component's schema definition.",
     type: "object",
-    id: "fancyButton",
     properties: {
         children: {
             title: "Default slot",

--- a/packages/design-to-code-react/app/pages/web-components/index.ts
+++ b/packages/design-to-code-react/app/pages/web-components/index.ts
@@ -7,12 +7,12 @@ export enum TestDataType {
 }
 
 const webComponentSchemas: any = {
-    [fancyButtonSchema.id]: {
+    [fancyButtonSchema.$id]: {
         data: {},
         type: TestDataType.element,
         schema: fancyButtonSchema,
     },
-    [textSchema.id]: {
+    [textSchema.$id]: {
         data: "foo",
         type: TestDataType.string,
         schema: textSchema,

--- a/packages/design-to-code-react/app/pages/web-components/text.schema.ts
+++ b/packages/design-to-code-react/app/pages/web-components/text.schema.ts
@@ -1,7 +1,7 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "text",
     title: "Text",
     description: "A test component's schema definition.",
     type: "string",
-    id: "text",
 };

--- a/packages/design-to-code-react/src/__tests__/schemas/align-horizontal.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/align-horizontal.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "alignHorizontal",
     title: "Component with horizontal alignment",
     description: "A test component's schema definition.",
     type: "object",
-    id: "alignHorizontal",
     properties: {
         alignHorizontal: {
             title: "Horizontal alignment",

--- a/packages/design-to-code-react/src/__tests__/schemas/all-control-types.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/all-control-types.schema.ts
@@ -2,10 +2,10 @@ import { linkedDataSchema } from "design-to-code";
 
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "allControlTypes",
     title: "Component with all control types",
     description: "A test component's schema definition.",
     type: "object",
-    id: "allControlTypes",
     properties: {
         textarea: {
             title: "textarea",

--- a/packages/design-to-code-react/src/__tests__/schemas/any-of.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/any-of.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "anyOf",
     title: "Component with anyOf",
     description: "A test component's schema definition.",
     type: "object",
-    id: "anyOf",
     anyOf: [
         {
             description: "String",

--- a/packages/design-to-code-react/src/__tests__/schemas/arrays.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/arrays.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "arrays",
     title: "Component with array",
     description: "A test component's schema definition.",
     type: "object",
-    id: "arrays",
     properties: {
         strings: {
             title: "Array of strings",

--- a/packages/design-to-code-react/src/__tests__/schemas/badge.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/badge.schema.ts
@@ -2,10 +2,10 @@ import { linkedDataSchema } from "design-to-code";
 
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "badge",
     title: "Badge",
     description: "A test component's schema definition.",
     type: "object",
-    id: "badge",
     properties: {
         string: {
             title: "Textarea",

--- a/packages/design-to-code-react/src/__tests__/schemas/category.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/category.schema.ts
@@ -2,11 +2,10 @@ import { linkedDataSchema } from "design-to-code";
 
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "category",
     title: "Category",
     description: "A test component's schema definition.",
     type: "object",
-    $id: "category",
-    id: "category",
     properties: {
         string: {
             title: "Textarea",

--- a/packages/design-to-code-react/src/__tests__/schemas/checkbox.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/checkbox.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "checkbox",
     title: "Component with checkbox",
     description: "A test component's schema definition.",
     type: "object",
-    id: "checkbox",
     properties: {
         toggle: {
             title: "Required Checkbox",

--- a/packages/design-to-code-react/src/__tests__/schemas/children-plugin.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/children-plugin.schema.ts
@@ -2,10 +2,10 @@ import { linkedDataSchema } from "design-to-code";
 
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "children-with-react-props",
     title: "Component with custom properties ",
     description: "A test component's schema definition.",
     type: "object",
-    id: "children-with-react-props",
     properties: {
         boolean: {
             title: "Boolean",

--- a/packages/design-to-code-react/src/__tests__/schemas/children.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/children.schema.ts
@@ -2,11 +2,11 @@ import { linkedDataSchema } from "design-to-code";
 
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "children",
     title: "Component with children",
     alias: "With Children",
     description: "A test component's schema definition.",
     type: "object",
-    id: "children",
     properties: {
         objectContainingNestedChildren: {
             title: "Object with nested children",

--- a/packages/design-to-code-react/src/__tests__/schemas/component-plugin.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/component-plugin.schema.ts
@@ -1,8 +1,8 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "component-with-plugin-interpretation",
     title: "Component interpreted by a plugin",
     description: "A test component's schema definition.",
     type: "string",
-    id: "component-with-plugin-interpretation",
     pluginId: "string-plugin-resolver",
 };

--- a/packages/design-to-code-react/src/__tests__/schemas/const.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/const.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "constKeyword",
     title: "Component with const",
     description: "A test component's schema definition.",
     type: "object",
-    id: "constKeyword",
     properties: {
         foo: {
             title: "Required with default",

--- a/packages/design-to-code-react/src/__tests__/schemas/control-plugin.css-with-overrides.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/control-plugin.css-with-overrides.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "controlPluginCssWithOverrides",
     title: "Component with custom CSS controls with overrides",
     description: "A test component's schema definition.",
     type: "object",
-    id: "controlPluginCssWithOverrides",
     properties: {
         cssWithOverrides: {
             title: "CSS with overrides",

--- a/packages/design-to-code-react/src/__tests__/schemas/control-plugin.css.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/control-plugin.css.schema.ts
@@ -2,10 +2,10 @@ import { linkedDataSchema } from "design-to-code";
 
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "controlPluginCss",
     title: "Component with custom CSS controls",
     description: "A test component's schema definition.",
     type: "object",
-    id: "controlPluginCss",
     properties: {
         css: {
             title: "CSS",

--- a/packages/design-to-code-react/src/__tests__/schemas/control-plugin.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/control-plugin.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "customControl",
     title: "Component with custom controls",
     description: "A test component's schema definition.",
     type: "object",
-    id: "customControl",
     properties: {
         file: {
             title: "File",

--- a/packages/design-to-code-react/src/__tests__/schemas/defaults.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/defaults.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "defaults",
     title: "Component with defaults",
     description: "A test component's schema definition.",
     type: "object",
-    id: "defaults",
     properties: {
         a: {
             title: "With default",

--- a/packages/design-to-code-react/src/__tests__/schemas/definitions.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/definitions.schema.ts
@@ -1,6 +1,6 @@
 export default {
     $schema: "http://json-schema.org/schema#",
-    id: "definitions",
+    $id: "definitions",
     title: "A schema with definitions",
     type: "object",
     properties: {

--- a/packages/design-to-code-react/src/__tests__/schemas/dictionary.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/dictionary.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "dictionary",
     title: "Component with additional properties",
     description: "A test component's schema definition.",
     type: "object",
-    id: "dictionary",
     propertyTitle: "Item key",
     properties: {
         additionalObjects: {

--- a/packages/design-to-code-react/src/__tests__/schemas/disabled.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/disabled.schema.ts
@@ -2,10 +2,10 @@ import { linkedDataSchema } from "design-to-code";
 
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "disabled",
     title: "Component with all disabled types",
     description: "A test component's schema definition.",
     type: "object",
-    id: "disabled",
     disabled: true,
     properties: {
         textarea: {

--- a/packages/design-to-code-react/src/__tests__/schemas/general-example.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/general-example.schema.ts
@@ -2,10 +2,10 @@ import { linkedDataSchema } from "design-to-code";
 
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "generalExample",
     title: "General example",
     description: "A test component's schema definition.",
     type: "object",
-    id: "generalExample",
     properties: {
         title: {
             title: "Title",

--- a/packages/design-to-code-react/src/__tests__/schemas/general.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/general.schema.ts
@@ -2,10 +2,10 @@ import { linkedDataSchema } from "design-to-code";
 
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "generalExample",
     title: "General example",
     description: "A test component's schema definition.",
     type: "object",
-    id: "generalExample",
     properties: {
         title: {
             title: "Title",

--- a/packages/design-to-code-react/src/__tests__/schemas/invalid-data.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/invalid-data.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "invalidData",
     title: "Component with invalid data",
     description: "A test component's schema definition.",
     type: "object",
-    id: "invalidData",
     properties: {
         invalidBooleanWrongType: {
             title: "Invalid boolean wrong type",

--- a/packages/design-to-code-react/src/__tests__/schemas/merged-one-of.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/merged-one-of.schema.ts
@@ -1,7 +1,7 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "mergedOneOf",
     type: "object",
-    id: "mergedOneOf",
     title: "Merged oneOf",
     properties: {
         foo: {

--- a/packages/design-to-code-react/src/__tests__/schemas/nested-one-of.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/nested-one-of.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "nestedOneOf",
     title: "Component with a nested oneOf",
     description: "A test component's schema definition.",
     type: "object",
-    id: "nestedOneOf",
     properties: {
         single: {
             title: "Single oneOf",

--- a/packages/design-to-code-react/src/__tests__/schemas/null.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/null.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "nullKeyword",
     title: "Component with null",
     description: "A test component's schema definition.",
     type: "object",
-    id: "nullKeyword",
     properties: {
         optionalNull: {
             title: "optional null",

--- a/packages/design-to-code-react/src/__tests__/schemas/number-field.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/number-field.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "numberField",
     title: "Component with number-field",
     description: "A test component's schema definition.",
     type: "object",
-    id: "numberField",
     properties: {
         level: {
             title: "Level",

--- a/packages/design-to-code-react/src/__tests__/schemas/objects.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/objects.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "objects",
     title: "Component with objects",
     description: "A test component's schema definition.",
     type: "object",
-    id: "objects",
     properties: {
         objectNoRequired: {
             title: "object with no required items",

--- a/packages/design-to-code-react/src/__tests__/schemas/one-of-deeply-nested.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/one-of-deeply-nested.schema.ts
@@ -1,8 +1,8 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "oneOfArrays",
     title: "Complex nesting arrays with oneOf",
     type: "object",
-    id: "oneOfArrays",
     properties: {
         propertyKey: {
             title: "Property key",

--- a/packages/design-to-code-react/src/__tests__/schemas/one-of.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/one-of.schema.ts
@@ -2,10 +2,10 @@ import { linkedDataSchema } from "design-to-code";
 
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "oneOf",
     title: "Component with oneOf",
     description: "A test component's schema definition.",
     type: "object",
-    id: "oneOf",
     oneOf: [
         {
             description: "string",

--- a/packages/design-to-code-react/src/__tests__/schemas/text-field.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/text-field.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "textField",
     title: "Component with text-field",
     description: "A test component's schema definition.",
     type: "object",
-    id: "textField",
     properties: {
         tag: {
             title: "Tag",

--- a/packages/design-to-code-react/src/__tests__/schemas/text.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/text.schema.ts
@@ -1,7 +1,7 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "text",
     description: "A test component's schema definition.",
-    id: "text",
     title: "Text",
     type: "string",
     examples: ["Example text"],

--- a/packages/design-to-code-react/src/__tests__/schemas/textarea.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/textarea.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "textField",
     title: "Component with text-field",
     description: "A test component's schema definition.",
     type: "object",
-    id: "textField",
     properties: {
         tag: {
             title: "Tag",

--- a/packages/design-to-code-react/src/__tests__/schemas/tooltip.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/tooltip.schema.ts
@@ -1,9 +1,9 @@
 export default {
     $schema: "http://json-schema.org/schema#",
+    $id: "tooltip",
     title: "Component with tooltips",
     description: "A test component's schema definition.",
     type: "object",
-    id: "tooltip",
     properties: {
         labelOnStandardControl: {
             title: "My label 1",

--- a/packages/design-to-code-react/src/data-utilities/mapping.spec.tsx
+++ b/packages/design-to-code-react/src/data-utilities/mapping.spec.tsx
@@ -45,7 +45,7 @@ describe("reactMapper", () => {
             resolver: reactResolver,
             schemaDictionary: {
                 foo: {
-                    id: "foo",
+                    $id: "foo",
                     type: "object",
                     properties: {
                         text: {
@@ -105,7 +105,7 @@ describe("reactMapper", () => {
             resolver: reactResolver,
             schemaDictionary: {
                 foo: {
-                    id: "foo",
+                    $id: "foo",
                     type: "object",
                     properties: {
                         children: {
@@ -114,7 +114,7 @@ describe("reactMapper", () => {
                     },
                 },
                 bar: {
-                    id: "bar",
+                    $id: "bar",
                     type: "string",
                 },
             },
@@ -169,7 +169,7 @@ describe("reactMapper", () => {
                 resolver: reactResolver,
                 schemaDictionary: {
                     foo: {
-                        id: "foo",
+                        $id: "foo",
                         type: "object",
                         properties: {
                             children: {
@@ -178,7 +178,7 @@ describe("reactMapper", () => {
                         },
                     },
                     bar: {
-                        id: "bar",
+                        $id: "bar",
                         type: "object",
                         properties: {
                             children: {
@@ -187,7 +187,7 @@ describe("reactMapper", () => {
                         },
                     },
                     bat: {
-                        id: "bat",
+                        $id: "bat",
                         type: DataType.string,
                     },
                 },
@@ -220,7 +220,7 @@ describe("reactMapper", () => {
             resolver: reactResolver,
             schemaDictionary: {
                 foo: {
-                    id: "foo",
+                    $id: "foo",
                     type: "object",
                     properties: {
                         text: {
@@ -282,7 +282,7 @@ describe("reactMapper", () => {
             resolver: reactResolver,
             schemaDictionary: {
                 foo: {
-                    id: "foo",
+                    $id: "foo",
                     type: "object",
                     properties: {
                         children: {

--- a/packages/design-to-code-react/src/data-utilities/mapping.tsx
+++ b/packages/design-to-code-react/src/data-utilities/mapping.tsx
@@ -67,7 +67,7 @@ export function reactMapper(
         const allAvailableProps = Object.keys(config.schema[PropertyKeyword.properties]);
 
         config.dataDictionary[0][config.dictionaryId].data = {
-            component: componentDictionary[config.schema.id],
+            component: componentDictionary[config.schema.$id],
             props: allAvailableProps
                 .filter(potentialProp => {
                     // remove slots from the attributes list

--- a/packages/design-to-code-react/src/form/controls/utilities/form.spec.ts
+++ b/packages/design-to-code-react/src/form/controls/utilities/form.spec.ts
@@ -30,20 +30,20 @@ describe("getSchemaByDataLocation", () => {
             },
         ]);
 
-        expect(schema.id).toBe(textFieldSchema.id);
+        expect(schema.$id).toBe(textFieldSchema.$id);
     });
     test("should return the schema given from data with a single child", () => {
         const data: any = {
             children: {
-                id: childrenSchema.id,
+                id: childrenSchema.$id,
                 props: {
                     children: [
                         {
-                            id: childrenSchema.id,
+                            id: childrenSchema.$id,
                             props: {},
                         },
                         {
-                            id: textFieldSchema.id,
+                            id: textFieldSchema.$id,
                             props: {
                                 tag: "span",
                                 text: "test",
@@ -65,7 +65,7 @@ describe("getSchemaByDataLocation", () => {
                 },
             ]
         );
-        expect(schema1.id).toBe(childrenSchema.id);
+        expect(schema1.$id).toBe(childrenSchema.$id);
 
         const schema2: any = getSchemaByDataLocation(
             childrenSchema,
@@ -79,7 +79,7 @@ describe("getSchemaByDataLocation", () => {
                 },
             ]
         );
-        expect(schema2.id).toBe(textFieldSchema.id);
+        expect(schema2.$id).toBe(textFieldSchema.$id);
     });
 });
 

--- a/packages/design-to-code-react/src/form/controls/utilities/form.tsx
+++ b/packages/design-to-code-react/src/form/controls/utilities/form.tsx
@@ -395,7 +395,7 @@ export function getSchemaByDataLocation(
     const id: string | undefined = subData ? subData.id : void 0;
     const childOptionWithMatchingSchemaId: any = childOptions.find(
         (childOption: FormChildOptionItem) => {
-            return childOption.schema.id === id;
+            return childOption.schema.$id === id;
         }
     );
 
@@ -414,9 +414,8 @@ export function getErrorFromDataLocation(
     let error: string = "";
 
     if (Array.isArray(validationErrors)) {
-        const normalizedDataLocation: string = normalizeDataLocationToDotNotation(
-            dataLocation
-        );
+        const normalizedDataLocation: string =
+            normalizeDataLocationToDotNotation(dataLocation);
 
         for (const validationError of validationErrors) {
             if (normalizedDataLocation === validationError.dataLocation) {
@@ -427,9 +426,8 @@ export function getErrorFromDataLocation(
                 if (normalizedDataLocation === "") {
                     containsInvalidData = true;
                 } else {
-                    const dataLocations: string[] = validationError.dataLocation.split(
-                        "."
-                    );
+                    const dataLocations: string[] =
+                        validationError.dataLocation.split(".");
 
                     containsInvalidData = dataLocations.some(
                         (value: string, index: number) => {
@@ -507,7 +505,7 @@ export function updateControlSectionState(
               }
             : null,
         categories:
-            state !== undefined && props.schema.id === state.schema.id
+            state !== undefined && props.schema.$id === state.schema.$id
                 ? getUpdatedCategories(state.categories)
                 : getCategoryStateFromCategoryDictionary(
                       props.categories,

--- a/packages/design-to-code-react/src/navigation/navigation.spec.tsx
+++ b/packages/design-to-code-react/src/navigation/navigation.spec.tsx
@@ -136,14 +136,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -162,7 +162,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -249,14 +249,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -275,7 +275,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -343,14 +343,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -373,7 +373,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -442,14 +442,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -468,7 +468,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -553,14 +553,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -579,7 +579,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -846,14 +846,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -872,7 +872,7 @@ describe("Navigation", () => {
                 dataDictionary: [
                     {
                         foo: {
-                            schemaId: schema.id,
+                            schemaId: schema.$id,
                             data: {
                                 children: [
                                     {
@@ -886,7 +886,7 @@ describe("Navigation", () => {
                                 id: "foo",
                                 dataLocation: "children",
                             },
-                            schemaId: schema.id,
+                            schemaId: schema.$id,
                             data: {
                                 text: "bar",
                             },
@@ -1108,15 +1108,15 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema1.id,
+                        schemaId: schema1.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema1.id]: schema1,
-                [schema2.id]: schema2,
+                [schema1.$id]: schema1,
+                [schema2.$id]: schema2,
             },
         });
 
@@ -1135,7 +1135,7 @@ describe("Navigation", () => {
                 dataDictionary: [
                     {
                         foo: {
-                            schemaId: schema1.id,
+                            schemaId: schema1.$id,
                             data: {
                                 children: [
                                     {
@@ -1149,7 +1149,7 @@ describe("Navigation", () => {
                                 id: "foo",
                                 dataLocation: "children",
                             },
-                            schemaId: schema2.id,
+                            schemaId: schema2.$id,
                             data: "bar",
                         },
                     },
@@ -1231,14 +1231,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -1253,7 +1253,7 @@ describe("Navigation", () => {
                 dataDictionary: [
                     {
                         foo: {
-                            schemaId: schema.id,
+                            schemaId: schema.$id,
                             data: {
                                 children: {},
                             },
@@ -1307,14 +1307,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -1333,7 +1333,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -1428,14 +1428,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -1454,7 +1454,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -1548,14 +1548,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -1574,7 +1574,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -1668,14 +1668,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -1694,7 +1694,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -1776,7 +1776,7 @@ describe("Navigation", () => {
         const dataDictionary: DataDictionary<any> = [
             {
                 "": {
-                    schemaId: schema.id,
+                    schemaId: schema.$id,
                     data,
                 },
                 foo: {
@@ -1784,7 +1784,7 @@ describe("Navigation", () => {
                         id: "",
                         dataLocation: "children",
                     },
-                    schemaId: schema.id,
+                    schemaId: schema.$id,
                     data: {
                         bar: "Hello world",
                     },
@@ -1848,7 +1848,7 @@ describe("Navigation", () => {
             webWorker: "",
             dataDictionary,
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -1949,7 +1949,7 @@ describe("Navigation", () => {
         const dataDictionary: DataDictionary<any> = [
             {
                 "": {
-                    schemaId: schema.id,
+                    schemaId: schema.$id,
                     data,
                 },
                 foo: {
@@ -1957,7 +1957,7 @@ describe("Navigation", () => {
                         id: "",
                         dataLocation: "children",
                     },
-                    schemaId: schema.id,
+                    schemaId: schema.$id,
                     data: {
                         obj: {},
                     },
@@ -2033,7 +2033,7 @@ describe("Navigation", () => {
             webWorker: "",
             dataDictionary,
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -2160,14 +2160,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -2190,7 +2190,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -2279,14 +2279,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -2309,7 +2309,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -2376,14 +2376,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -2406,7 +2406,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -2473,14 +2473,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -2503,7 +2503,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -2570,14 +2570,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -2600,7 +2600,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },
@@ -2667,14 +2667,14 @@ describe("Navigation", () => {
             dataDictionary: [
                 {
                     "": {
-                        schemaId: schema.id,
+                        schemaId: schema.$id,
                         data,
                     },
                 },
                 "",
             ],
             schemaDictionary: {
-                [schema.id]: schema,
+                [schema.$id]: schema,
             },
         });
 
@@ -2697,7 +2697,7 @@ describe("Navigation", () => {
                     dataDictionary: [
                         {
                             "": {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data,
                             },
                         },

--- a/packages/design-to-code/src/data-utilities/mapping.vscode-html-languageservice.spec.pw.ts
+++ b/packages/design-to-code/src/data-utilities/mapping.vscode-html-languageservice.spec.pw.ts
@@ -86,7 +86,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ["foobar"],
                     schemaDictionary: {
-                        [textSchema.id]: textSchema,
+                        [textSchema.$id]: textSchema,
                     },
                 });
                 const root: string = value[1];
@@ -97,7 +97,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         );
 
         await expect(mappedValue).toMatchObject({
-            schemaId: textSchema.id,
+            schemaId: textSchema.$id,
             data: "foobar",
         });
     });
@@ -110,7 +110,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ["<div>", "</div>"],
                     schemaDictionary: {
-                        [divSchema.id]: divSchema,
+                        [divSchema.$id]: divSchema,
                     },
                 });
                 const root: string = value[1];
@@ -121,7 +121,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         );
 
         await expect(mappedValue).toMatchObject({
-            schemaId: divSchema.id,
+            schemaId: divSchema.$id,
             data: {},
         });
     });
@@ -134,7 +134,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ["<div>\n", "</div>"],
                     schemaDictionary: {
-                        [divSchema.id]: divSchema,
+                        [divSchema.$id]: divSchema,
                     },
                 });
                 const root: string = value[1];
@@ -144,7 +144,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         );
 
         await expect(mappedValue).toMatchObject({
-            schemaId: divSchema.id,
+            schemaId: divSchema.$id,
             data: {},
         });
     });
@@ -157,7 +157,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ['<input id="bar" />'],
                     schemaDictionary: {
-                        [inputSchema.id]: inputSchema,
+                        [inputSchema.$id]: inputSchema,
                     },
                 });
                 const root: string = value[1];
@@ -167,7 +167,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         );
 
         await expect(mappedValue).toMatchObject({
-            schemaId: inputSchema.id,
+            schemaId: inputSchema.$id,
             data: {
                 id: "bar",
             },
@@ -182,7 +182,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ['<input name="1" />'],
                     schemaDictionary: {
-                        [inputSchema.id]: inputSchema,
+                        [inputSchema.$id]: inputSchema,
                     },
                 });
                 const root: string = value[1];
@@ -192,7 +192,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         );
 
         await expect(mappedValue).toMatchObject({
-            schemaId: inputSchema.id,
+            schemaId: inputSchema.$id,
             data: {
                 name: "1",
             },
@@ -207,7 +207,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ['<input slot="bar" />'],
                     schemaDictionary: {
-                        [inputSchema.id]: inputSchema,
+                        [inputSchema.$id]: inputSchema,
                     },
                 });
                 const root: string = value[1];
@@ -217,7 +217,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         );
 
         await expect(mappedValue).toMatchObject({
-            schemaId: inputSchema.id,
+            schemaId: inputSchema.$id,
             data: {},
         });
     });
@@ -230,7 +230,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ['<input value="5" />'],
                     schemaDictionary: {
-                        [inputSchema.id]: inputSchema,
+                        [inputSchema.$id]: inputSchema,
                     },
                 });
                 const root: string = value[1];
@@ -240,7 +240,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         );
 
         await expect(mappedValue).toMatchObject({
-            schemaId: inputSchema.id,
+            schemaId: inputSchema.$id,
             data: {
                 value: 5,
             },
@@ -255,7 +255,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ["<input required />"],
                     schemaDictionary: {
-                        [inputSchema.id]: inputSchema,
+                        [inputSchema.$id]: inputSchema,
                     },
                 });
                 const root: string = value[1];
@@ -265,7 +265,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         );
 
         await expect(mappedValue).toMatchObject({
-            schemaId: inputSchema.id,
+            schemaId: inputSchema.$id,
             data: {
                 required: true,
             },
@@ -280,7 +280,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ['<input data-id="foo" />'],
                     schemaDictionary: {
-                        [inputSchema.id]: inputSchema,
+                        [inputSchema.$id]: inputSchema,
                     },
                 });
                 const root: string = value[1];
@@ -290,7 +290,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         );
 
         await expect(mappedValue).toMatchObject({
-            schemaId: inputSchema.id,
+            schemaId: inputSchema.$id,
             data: {
                 "data-id": "foo",
             },
@@ -305,7 +305,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ["<input data-id />"],
                     schemaDictionary: {
-                        [inputSchema.id]: inputSchema,
+                        [inputSchema.$id]: inputSchema,
                     },
                 });
                 const root: string = value[1];
@@ -315,7 +315,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         );
 
         await expect(mappedValue).toMatchObject({
-            schemaId: inputSchema.id,
+            schemaId: inputSchema.$id,
             data: {
                 "data-id": true,
             },
@@ -330,7 +330,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ["<input data-id= bar />"],
                     schemaDictionary: {
-                        [inputSchema.id]: inputSchema,
+                        [inputSchema.$id]: inputSchema,
                     },
                 });
                 const root: string = value[1];
@@ -351,8 +351,8 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ["<div>", "<input />", "</div>"],
                     schemaDictionary: {
-                        [inputSchema.id]: inputSchema,
-                        [divSchema.id]: divSchema,
+                        [inputSchema.$id]: inputSchema,
+                        [divSchema.$id]: divSchema,
                     },
                 });
                 const root: string = value[1];
@@ -363,7 +363,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         );
         const mappedValue = JSON.parse(mappedValueAsString[0]);
 
-        await expect(mappedValue.schemaId).toEqual(inputSchema.id);
+        await expect(mappedValue.schemaId).toEqual(inputSchema.$id);
         await expect(mappedValue.data).toMatchObject({});
         await expect(mappedValue.parent.id).toEqual(mappedValueAsString[1]);
         await expect(mappedValue.parent.dataLocation).toEqual("Slot");
@@ -378,8 +378,8 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ["<div>", "foobar", "</div>"],
                     schemaDictionary: {
-                        [textSchema.id]: textSchema,
-                        [divSchema.id]: divSchema,
+                        [textSchema.$id]: textSchema,
+                        [divSchema.$id]: divSchema,
                     },
                 });
                 const root: string = value[1];
@@ -390,7 +390,7 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         );
         const mappedValue = JSON.parse(mappedValueAsString[0]);
 
-        await expect(mappedValue.schemaId).toEqual(textSchema.id);
+        await expect(mappedValue.schemaId).toEqual(textSchema.$id);
         await expect(mappedValue.data).toEqual("foobar");
         await expect(mappedValue.parent.id).toEqual(mappedValueAsString[1]);
         await expect(mappedValue.parent.dataLocation).toEqual("Slot");
@@ -410,9 +410,9 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ["<div>", "foobar", "<input />", "</div>"],
                     schemaDictionary: {
-                        [textSchema.id]: textSchema,
-                        [divSchema.id]: divSchema,
-                        [inputSchema.id]: inputSchema,
+                        [textSchema.$id]: textSchema,
+                        [divSchema.$id]: divSchema,
+                        [inputSchema.$id]: inputSchema,
                     },
                 });
                 const root: string = value[1];
@@ -433,11 +433,11 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         const stringMappedValue = JSON.parse(mappedValueAsString[0]);
         const inputMappedValue = JSON.parse(mappedValueAsString[1]);
 
-        await expect(stringMappedValue.schemaId).toEqual(textSchema.id);
+        await expect(stringMappedValue.schemaId).toEqual(textSchema.$id);
         await expect(stringMappedValue.data).toEqual("foobar");
         await expect(stringMappedValue.parent.id).toEqual(mappedValueAsString[2]);
         await expect(stringMappedValue.parent.dataLocation).toEqual("Slot");
-        await expect(inputMappedValue.schemaId).toEqual(inputSchema.id);
+        await expect(inputMappedValue.schemaId).toEqual(inputSchema.$id);
         await expect(inputMappedValue.data).toMatchObject({});
         await expect(inputMappedValue.parent.id).toEqual(mappedValueAsString[2]);
         await expect(inputMappedValue.parent.dataLocation).toEqual("Slot");
@@ -457,9 +457,9 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ["<div>", "<input />", "foobar", "</div>"],
                     schemaDictionary: {
-                        [textSchema.id]: textSchema,
-                        [divSchema.id]: divSchema,
-                        [inputSchema.id]: inputSchema,
+                        [textSchema.$id]: textSchema,
+                        [divSchema.$id]: divSchema,
+                        [inputSchema.$id]: inputSchema,
                     },
                 });
                 const root: string = value[1];
@@ -480,11 +480,11 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         const stringMappedValue = JSON.parse(mappedValueAsString[0]);
         const inputMappedValue = JSON.parse(mappedValueAsString[1]);
 
-        await expect(inputMappedValue.schemaId).toEqual(inputSchema.id);
+        await expect(inputMappedValue.schemaId).toEqual(inputSchema.$id);
         await expect(inputMappedValue.data).toMatchObject({});
         await expect(inputMappedValue.parent.id).toEqual(mappedValueAsString[2]);
         await expect(inputMappedValue.parent.dataLocation).toEqual("Slot");
-        await expect(stringMappedValue.schemaId).toEqual(textSchema.id);
+        await expect(stringMappedValue.schemaId).toEqual(textSchema.$id);
         await expect(stringMappedValue.data).toEqual("foobar");
         await expect(stringMappedValue.parent.id).toEqual(mappedValueAsString[2]);
         await expect(stringMappedValue.parent.dataLocation).toEqual("Slot");
@@ -504,9 +504,9 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ["<div>", "<input />", "foobar", "<input />", "</div>"],
                     schemaDictionary: {
-                        [textSchema.id]: textSchema,
-                        [divSchema.id]: divSchema,
-                        [inputSchema.id]: inputSchema,
+                        [textSchema.$id]: textSchema,
+                        [divSchema.$id]: divSchema,
+                        [inputSchema.$id]: inputSchema,
                     },
                 });
                 const root: string = value[1];
@@ -530,15 +530,15 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
         const inputMappedValue1 = JSON.parse(mappedValueAsString[1]);
         const inputMappedValue2 = JSON.parse(mappedValueAsString[2]);
 
-        await expect(inputMappedValue1.schemaId).toEqual(inputSchema.id);
+        await expect(inputMappedValue1.schemaId).toEqual(inputSchema.$id);
         await expect(inputMappedValue1.data).toMatchObject({});
         await expect(inputMappedValue1.parent.id).toEqual(mappedValueAsString[3]);
         await expect(inputMappedValue1.parent.dataLocation).toEqual("Slot");
-        await expect(stringMappedValue.schemaId).toEqual(textSchema.id);
+        await expect(stringMappedValue.schemaId).toEqual(textSchema.$id);
         await expect(stringMappedValue.data).toEqual("foobar");
         await expect(stringMappedValue.parent.id).toEqual(mappedValueAsString[3]);
         await expect(stringMappedValue.parent.dataLocation).toEqual("Slot");
-        await expect(inputMappedValue2.schemaId).toEqual(inputSchema.id);
+        await expect(inputMappedValue2.schemaId).toEqual(inputSchema.$id);
         await expect(inputMappedValue2.data).toMatchObject({});
         await expect(inputMappedValue2.parent.id).toEqual(mappedValueAsString[3]);
         await expect(inputMappedValue2.parent.dataLocation).toEqual("Slot");
@@ -560,10 +560,10 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 const value = (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                     value: ["<div>", "<span>", "foobar", "</span>", "</div>"],
                     schemaDictionary: {
-                        [textSchema.id]: textSchema,
-                        [divSchema.id]: divSchema,
-                        [inputSchema.id]: inputSchema,
-                        [spanSchema.id]: spanSchema,
+                        [textSchema.$id]: textSchema,
+                        [divSchema.$id]: divSchema,
+                        [inputSchema.$id]: inputSchema,
+                        [spanSchema.$id]: spanSchema,
                     },
                 });
 
@@ -632,11 +632,11 @@ test.describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                         "</foo-bar>",
                     ],
                     schemaDictionary: {
-                        [textSchema.id]: textSchema,
-                        [divSchema.id]: divSchema,
-                        [inputSchema.id]: inputSchema,
-                        [spanSchema.id]: spanSchema,
-                        [customSchema.id]: customSchema,
+                        [textSchema.$id]: textSchema,
+                        [divSchema.$id]: divSchema,
+                        [inputSchema.$id]: inputSchema,
+                        [spanSchema.$id]: spanSchema,
+                        [customSchema.$id]: customSchema,
                     },
                 });
 
@@ -1867,7 +1867,7 @@ test.describe("mapVSCodeHTMLAndDataDictionaryToDataDictionary", () => {
                             "root",
                         ],
                         {
-                            [inputSchema.id]: inputSchema,
+                            [inputSchema.$id]: inputSchema,
                         }
                     )
                 );
@@ -1876,7 +1876,7 @@ test.describe("mapVSCodeHTMLAndDataDictionaryToDataDictionary", () => {
         );
 
         await expect(JSON.parse(mappedDataAsString)[0].root).toMatchObject({
-            schemaId: inputSchema.id,
+            schemaId: inputSchema.$id,
             data: {
                 required: true,
             },
@@ -1900,7 +1900,7 @@ test.describe("mapVSCodeHTMLAndDataDictionaryToDataDictionary", () => {
                             "root",
                         ],
                         {
-                            [inputSchema.id]: inputSchema,
+                            [inputSchema.$id]: inputSchema,
                         }
                     )
                 );
@@ -1909,7 +1909,7 @@ test.describe("mapVSCodeHTMLAndDataDictionaryToDataDictionary", () => {
         );
 
         await expect(JSON.parse(mappedDataAsString)[0].root).toMatchObject({
-            schemaId: inputSchema.id,
+            schemaId: inputSchema.$id,
             data: {
                 value: 5,
             },
@@ -1923,7 +1923,7 @@ test.describe("mapVSCodeHTMLAndDataDictionaryToDataDictionary", () => {
                     (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                         value: ['<input name="foo" />'],
                         schemaDictionary: {
-                            [inputSchema.id]: inputSchema,
+                            [inputSchema.$id]: inputSchema,
                         },
                     })
                 );
@@ -1934,7 +1934,7 @@ test.describe("mapVSCodeHTMLAndDataDictionaryToDataDictionary", () => {
         const root: string = mappedData[1];
 
         await expect(mappedData[0][root]).toMatchObject({
-            schemaId: inputSchema.id,
+            schemaId: inputSchema.$id,
             data: {
                 name: "foo",
             },
@@ -1950,7 +1950,7 @@ test.describe("mapVSCodeHTMLAndDataDictionaryToDataDictionary", () => {
                     (window as any).dtc.mapVSCodeParsedHTMLToDataDictionary({
                         value: ['<input name="1" />'],
                         schemaDictionary: {
-                            [inputSchema.id]: inputSchema,
+                            [inputSchema.$id]: inputSchema,
                         },
                     })
                 );
@@ -1961,7 +1961,7 @@ test.describe("mapVSCodeHTMLAndDataDictionaryToDataDictionary", () => {
         const mappedData = JSON.parse(mappedDataAsString);
         const root: string = mappedData[1];
         expect(mappedData[0][root]).toMatchObject({
-            schemaId: inputSchema.id,
+            schemaId: inputSchema.$id,
             data: {
                 name: "1",
             },

--- a/packages/design-to-code/src/message-system-service/ajv-validation.service.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/ajv-validation.service.spec.pw.ts
@@ -134,7 +134,7 @@ test.describe("AjvMapper", () => {
         const mappedData = await page.evaluate(
             ([dataTypeObject, messageTypeInitialize]: [DataType, MessageSystemType]) => {
                 const schema: any = {
-                    id: "foo",
+                    $id: "foo",
                 };
                 const data = undefined;
                 const messageSystem = new (window as any).dtc.MessageSystem({
@@ -225,7 +225,7 @@ test.describe("AjvMapper", () => {
             ([dataTypeObject, messageTypeInitialize]: [DataType, MessageSystemType]) => {
                 const schema: any = {
                     $schema: "http://json-schema.org/schema#",
-                    id: "foo",
+                    $id: "foo",
                     type: "string",
                 };
                 const data = 42;
@@ -318,7 +318,7 @@ test.describe("AjvMapper", () => {
     test.describe("should call the message callback if a data message has been sent", async () => {
         const schema: any = {
             $schema: "http://json-schema.org/schema#",
-            id: "foo",
+            $id: "foo",
             type: "string",
         };
         const schemaAsString = JSON.stringify(schema);
@@ -480,7 +480,7 @@ test.describe("AjvMapper", () => {
                     const navigationDictionary = JSON.parse(navigationDictionaryAsString);
                     const schema2: any = {
                         $schema: "http://json-schema.org/schema#",
-                        id: "bar",
+                        $id: "bar",
                         type: "boolean",
                     };
                     const messageSystem = new (window as any).dtc.MessageSystem({

--- a/packages/design-to-code/src/message-system-service/ajv-validation.service.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/ajv-validation.service.spec.pw.ts
@@ -142,7 +142,7 @@ test.describe("AjvMapper", () => {
                     dataDictionary: [
                         {
                             foo: {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data: undefined,
                             },
                         },
@@ -234,7 +234,7 @@ test.describe("AjvMapper", () => {
                     dataDictionary: [
                         {
                             foo: {
-                                schemaId: schema.id,
+                                schemaId: schema.$id,
                                 data: undefined,
                             },
                         },
@@ -326,7 +326,7 @@ test.describe("AjvMapper", () => {
         const dataDictionary: DataDictionary<unknown> = [
             {
                 foo: {
-                    schemaId: schema.id,
+                    schemaId: schema.$id,
                     data,
                 },
             },

--- a/packages/design-to-code/src/message-system-service/ajv-validation.service.ts
+++ b/packages/design-to-code/src/message-system-service/ajv-validation.service.ts
@@ -176,12 +176,12 @@ export class AjvMapper {
     private validateData = (data: any, schema: any): ValidationError[] => {
         // if this data has never been validated against,
         // add the schema to ajv
-        if (this.schemaDictionary[schema.id] === undefined) {
-            this.schemaDictionary[schema.id] = schema;
-            this.ajv.addSchema(schema, schema.id);
+        if (this.schemaDictionary[schema.$id] === undefined) {
+            this.schemaDictionary[schema.$id] = schema;
+            this.ajv.addSchema(schema, schema.$id);
         }
 
-        const ajvValidationObject = this.ajv.validate(schema.id, data);
+        const ajvValidationObject = this.ajv.validate(schema.$id, data);
 
         if (ajvValidationObject === true) {
             return [];


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change specifies the use of `$id`, and therefore doesn't support JSON schema draft 4. It has been specified that only the latest draft (as of this change) is being supported.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.