### PR TITLE
Rename Ajv validater export, move ajv dependency, bump packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15942,14 +15942,14 @@
       }
     },
     "packages/design-to-code-react": {
-      "version": "1.0.0-alpha.5",
+      "version": "1.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
         "@microsoft/fast-element": "^1.5.1",
         "@microsoft/fast-foundation": "^2.13.1",
         "@microsoft/fast-web-utilities": "^4.8.1",
         "@skatejs/val": "^0.5.0",
-        "design-to-code": "^1.0.0-alpha.4",
+        "design-to-code": "^1.0.0-alpha.5",
         "exenv-es6": "^1.0.0",
         "raf-throttle": "^2.0.3",
         "react-dnd": "^16.0.0"
@@ -21912,7 +21912,7 @@
         "@types/react": "^18.0.0",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.7.3",
-        "design-to-code": "^1.0.0-alpha.4",
+        "design-to-code": "^1.0.0-alpha.5",
         "eslint-config-prettier": "^6.10.1",
         "eslint-plugin-react": "^7.19.0",
         "exenv-es6": "^1.0.0",

--- a/packages/design-to-code-react/app/pages/form.tsx
+++ b/packages/design-to-code-react/app/pages/form.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
-    AjvMapper,
+    AjvValidator,
     MessageSystem,
     getDataFromSchema,
     MessageSystemType,
@@ -13,7 +13,7 @@ import { Form } from "../../src";
 const messageSystem = new MessageSystem({
     webWorker: "message-system.js",
 });
-new AjvMapper({
+new AjvValidator({
     messageSystem,
     ajvOptions: {
         strict: false,

--- a/packages/design-to-code-react/app/pages/form/index.ts
+++ b/packages/design-to-code-react/app/pages/form/index.ts
@@ -4,7 +4,6 @@ export interface ExampleComponent {
 }
 
 import {
-    shippingSchema,
     allControlTypesSchema,
     anyOfSchema,
     arraysSchema,
@@ -42,6 +41,7 @@ import {
     oneOfDeeplyNestedSchema as oneOfArraysSchema,
     oneOfSchema,
     recursiveDefinitionsSchema,
+    shippingSchema,
     textareaSchema,
     textSchema,
     tooltipSchema,

--- a/packages/design-to-code-react/app/pages/form/index.ts
+++ b/packages/design-to-code-react/app/pages/form/index.ts
@@ -4,6 +4,7 @@ export interface ExampleComponent {
 }
 
 import {
+    shippingSchema,
     allControlTypesSchema,
     anyOfSchema,
     arraysSchema,
@@ -233,4 +234,8 @@ export const controlArrayDisabled: ExampleComponent = {
 export const controlArrayInvalid: ExampleComponent = {
     schema: controlArraySchema,
     data: "foo",
+};
+
+export const shipping: ExampleComponent = {
+    schema: shippingSchema,
 };

--- a/packages/design-to-code-react/package.json
+++ b/packages/design-to-code-react/package.json
@@ -2,7 +2,7 @@
   "name": "design-to-code-react",
   "description": "A React-specific set of components and utilities to assist in creating web UI",
   "sideEffects": false,
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "author": "Jane Chu",
   "license": "MIT",
   "repository": {
@@ -118,7 +118,7 @@
     "@microsoft/fast-foundation": "^2.13.1",
     "@microsoft/fast-web-utilities": "^4.8.1",
     "@skatejs/val": "^0.5.0",
-    "design-to-code": "^1.0.0-alpha.4",
+    "design-to-code": "^1.0.0-alpha.5",
     "exenv-es6": "^1.0.0",
     "raf-throttle": "^2.0.3",
     "react-dnd": "^16.0.0"

--- a/packages/design-to-code-react/src/__tests__/schemas/index.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/index.ts
@@ -31,6 +31,7 @@ import textFieldSchema from "./text-field.schema";
 import textareaSchema from "./textarea.schema";
 import textSchema from "./text.schema";
 import tooltipSchema from "./tooltip.schema";
+import shippingSchema from "./shipping.schema";
 
 /**
  * Controls
@@ -49,6 +50,7 @@ import controlTextareaDefaultSchema from "./control.textarea.default.schema";
 import controlTextareaDisabledSchema from "./control.textarea.disabled.schema";
 
 export {
+    shippingSchema,
     alignHorizontalSchema,
     allControlTypesSchema,
     anyOfSchema,

--- a/packages/design-to-code-react/src/__tests__/schemas/shipping.schema.ts
+++ b/packages/design-to-code-react/src/__tests__/schemas/shipping.schema.ts
@@ -1,0 +1,49 @@
+export default {
+    $schema: "https://json-schema.org/draft/2019-09/schema",
+    $id: "/shipping.schema.json",
+    title: "Shipping information",
+    type: "object",
+    properties: {
+        first_name: {
+            title: "First Name",
+            type: "string"
+        },
+        last_name: {
+            title: "Last Name",
+            type: "string"
+        },
+        street_address: {
+            title: "Street",
+            type: "string"
+        },
+        city: {
+            title: "City",
+            type: "string"
+        },
+        zip: {
+            title: "Zip Code",
+            type: "number"
+        },
+        state: {
+            title: "State",
+            type: "string",
+            enum: [
+                "CA",
+                "PA",
+                "WA"
+            ]
+        },
+        gift_wrap: {
+            title: "Wrap this item",
+            type: "boolean"
+        }
+    },
+    required: [
+        "first_name",
+        "last_name",
+        "street_address",
+        "zip",
+        "city",
+        "state"
+    ]
+}

--- a/packages/design-to-code/app/examples/message-system/index.ts
+++ b/packages/design-to-code/app/examples/message-system/index.ts
@@ -1,5 +1,5 @@
 import {
-    AjvMapper,
+    AjvValidator,
     MessageSystem,
     MonacoAdapter,
     MonacoAdapterAction,
@@ -20,7 +20,7 @@ import schemaDictionary from "design-to-code/dist/esm/message-system-service/sho
  * These utilities are used for testing in browser
  */
 (window as any).dtc = {
-    AjvMapper,
+    AjvValidator,
     MessageSystem,
     MonacoAdapter,
     MonacoAdapterAction,

--- a/packages/design-to-code/package.json
+++ b/packages/design-to-code/package.json
@@ -2,7 +2,7 @@
   "name": "design-to-code",
   "description": "A set of utilities to assist in creating web UI",
   "sideEffects": false,
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "type": "module",
   "author": "Jane Chu",
   "license": "MIT",
@@ -41,7 +41,6 @@
   "devDependencies": {
     "@types/lodash-es": "^4.17.4",
     "@types/webpack-env": "^1.15.2",
-    "ajv": "^8.12.0",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^11.0.0",
     "copyfiles": "^2.4.1",
@@ -74,6 +73,7 @@
     "@microsoft/fast-colors": "^5.3.1",
     "@microsoft/fast-element": "^2.0.0-beta.23",
     "@microsoft/fast-web-utilities": "^4.8.1",
+    "ajv": "^8.12.0",
     "vscode-html-languageservice": "^3.1.3",
     "vscode-web-custom-data": "^0.3.5"
   }

--- a/packages/design-to-code/src/message-system-service/ajv-validator.service.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/ajv-validator.service.spec.pw.ts
@@ -14,10 +14,10 @@ import {
     UpdateDataMessageOutgoing,
 } from "../message-system/index.js";
 import { DataType } from "../data-utilities/types.js";
-import { AjvMapper, ajvValidationId } from "./ajv-validation.service.js";
+import { AjvValidator, ajvValidationId } from "./ajv-validator.service.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-test.describe("AjvMapper", () => {
+test.describe("AjvValidator", () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/message-system");
     });
@@ -39,7 +39,7 @@ test.describe("AjvMapper", () => {
                 },
             });
 
-            new (window as any).dtc.AjvMapper({
+            new (window as any).dtc.AjvValidator({
                 messageSystem,
             });
 
@@ -50,7 +50,7 @@ test.describe("AjvMapper", () => {
     });
     test("should not throw if the message system is undefined", async ({ page }) => {
         const didNotError = await page.evaluate(() => {
-            new (window as any).dtc.AjvMapper({
+            new (window as any).dtc.AjvValidator({
                 messageSystem: undefined,
             });
 
@@ -79,7 +79,7 @@ test.describe("AjvMapper", () => {
 
             const size1 = messageSystem["register"].size;
 
-            new (window as any).dtc.AjvMapper({
+            new (window as any).dtc.AjvValidator({
                 messageSystem,
             });
 
@@ -111,7 +111,7 @@ test.describe("AjvMapper", () => {
 
             const size1 = messageSystem["register"].size;
 
-            const ajvMapper = new (window as any).dtc.AjvMapper({
+            const ajvMapper = new (window as any).dtc.AjvValidator({
                 messageSystem,
             });
 
@@ -153,7 +153,7 @@ test.describe("AjvMapper", () => {
                     },
                 });
 
-                const ajvMapper = new (window as any).dtc.AjvMapper({
+                const ajvMapper = new (window as any).dtc.AjvValidator({
                     messageSystem,
                 });
 
@@ -245,7 +245,7 @@ test.describe("AjvMapper", () => {
                     },
                 });
 
-                const ajvMapper: AjvMapper = new (window as any).dtc.AjvMapper({
+                const ajvMapper: AjvValidator = new (window as any).dtc.AjvValidator({
                     messageSystem,
                 });
 
@@ -391,7 +391,7 @@ test.describe("AjvMapper", () => {
                             foo: schema,
                         },
                     });
-                    const ajvMapper: AjvMapper = new (window as any).dtc.AjvMapper({
+                    const ajvMapper: AjvValidator = new (window as any).dtc.AjvValidator({
                         messageSystem,
                     });
 
@@ -491,7 +491,7 @@ test.describe("AjvMapper", () => {
                             bar: schema2,
                         },
                     });
-                    const ajvMapper: AjvMapper = new (window as any).dtc.AjvMapper({
+                    const ajvMapper: AjvValidator = new (window as any).dtc.AjvValidator({
                         messageSystem,
                     });
 
@@ -609,7 +609,7 @@ test.describe("AjvMapper", () => {
                             foo: schema,
                         },
                     });
-                    const ajvMapper: AjvMapper = new (window as any).dtc.AjvMapper({
+                    const ajvMapper: AjvValidator = new (window as any).dtc.AjvValidator({
                         messageSystem,
                     });
 
@@ -702,7 +702,7 @@ test.describe("AjvMapper", () => {
                             foo: schema,
                         },
                     });
-                    const ajvMapper: AjvMapper = new (window as any).dtc.AjvMapper({
+                    const ajvMapper: AjvValidator = new (window as any).dtc.AjvValidator({
                         messageSystem,
                     });
 
@@ -795,7 +795,7 @@ test.describe("AjvMapper", () => {
                             foo: schema,
                         },
                     });
-                    const ajvMapper: AjvMapper = new (window as any).dtc.AjvMapper({
+                    const ajvMapper: AjvValidator = new (window as any).dtc.AjvValidator({
                         messageSystem,
                     });
 
@@ -910,7 +910,7 @@ test.describe("AjvMapper", () => {
                         schemaDictionary: null,
                     });
                     messageSystem.postMessage = postMessageCallback;
-                    new (window as any).dtc.AjvMapper({
+                    new (window as any).dtc.AjvValidator({
                         messageSystem,
                     });
                     messageSystem.add({
@@ -980,7 +980,7 @@ test.describe("AjvMapper", () => {
                         schemaDictionary: null,
                     });
                     messageSystem.postMessage = postMessageCallback;
-                    new (window as any).dtc.AjvMapper({
+                    new (window as any).dtc.AjvValidator({
                         messageSystem,
                     });
                     messageSystem.add({
@@ -1044,7 +1044,7 @@ test.describe("AjvMapper", () => {
                         schemaDictionary: null,
                     });
                     messageSystem.postMessage = postMessageCallback;
-                    new (window as any).dtc.AjvMapper({
+                    new (window as any).dtc.AjvValidator({
                         messageSystem,
                     });
                     messageSystem.add({

--- a/packages/design-to-code/src/message-system-service/ajv-validator.service.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/ajv-validator.service.spec.pw.ts
@@ -14,7 +14,7 @@ import {
     UpdateDataMessageOutgoing,
 } from "../message-system/index.js";
 import { DataType } from "../data-utilities/types.js";
-import { AjvValidator, ajvValidationId } from "./ajv-validator.service.js";
+import { ajvValidationId, AjvValidator } from "./ajv-validator.service.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 test.describe("AjvValidator", () => {

--- a/packages/design-to-code/src/message-system-service/index.ts
+++ b/packages/design-to-code/src/message-system-service/index.ts
@@ -1,4 +1,4 @@
-export * from "./ajv-validation.service.js";
+export * from "./ajv-validator.service.js";
 export * from "./monaco-adapter.service.js";
 export * from "./shortcuts.service.js";
 export * from "./shortcuts-service-actions/index.js";


### PR DESCRIPTION
# Pull Request

## 📖 Description

- Updates the naming for the Ajv validation service to Ajv validator service to be inline with the ajv library
- Adds a shipping JSON schema to be used in future as documentation
- Points to the Ajv2019 export as this is the current supported JSON schema version
- Bumps the packages

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.