### PR TITLE
Fixes an issue where the AJV service would throw an error when the `$id` is missing

### DIFF
--- a/packages/design-to-code/src/message-system-service/ajv-validator.service.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/ajv-validator.service.spec.pw.ts
@@ -1169,4 +1169,98 @@ test.describe("AjvValidator", () => {
             },
         ]);
     });
+    test("should mark a schema as invalid if it is missing an $id", async ({ page }) => {
+        const mappedData = await page.evaluate(
+            ([dataTypeObject, messageTypeInitialize]: [DataType, MessageSystemType]) => {
+                const schema = {
+                    $schema: "http://json-schema.org/schema#",
+                    type: "string",
+                };
+                const data = 42;
+                const messageSystem = new (window as any).dtc.MessageSystem({
+                    webWorker: "",
+                    dataDictionary: [
+                        {
+                            foo: {
+                                schemaId: undefined,
+                                data: undefined,
+                            },
+                        },
+                        "foo",
+                    ],
+                    schemaDictionary: {
+                        [undefined as any]: schema,
+                    },
+                });
+
+                const ajvMapper = new (window as any).dtc.AjvValidator({
+                    messageSystem,
+                });
+
+                const navigation = [
+                    {
+                        foo: {
+                            self: "foo",
+                            parent: null,
+                            relativeDataLocation: "",
+                            schemaLocation: "",
+                            schema,
+                            disabled: false,
+                            data,
+                            text: "foo",
+                            type: dataTypeObject,
+                            items: [],
+                        },
+                    },
+                    "foo",
+                ];
+
+                messageSystem["register"].forEach(registeredItem => {
+                    registeredItem.onMessage({
+                        data: {
+                            type: messageTypeInitialize,
+                            activeDictionaryId: "foo",
+                            activeNavigationConfigId: "foo",
+                            schema,
+                            data,
+                            dataDictionary: [
+                                {
+                                    foo: {
+                                        schemaId: "foo",
+                                        data,
+                                    },
+                                },
+                                "foo",
+                            ],
+                            navigationDictionary: [
+                                {
+                                    foo: navigation,
+                                },
+                                "foo",
+                            ],
+                            navigation,
+                            schemaDictionary: {
+                                foo: schema,
+                            },
+                            validation: {},
+                            activeHistoryIndex: 0,
+                            dictionaryId: "foo",
+                            historyId: "1",
+                            historyLimit: 30,
+                        },
+                    });
+                });
+
+                return JSON.stringify(ajvMapper["schemaValidation"]);
+            },
+            [DataType.object, MessageSystemType.initialize]
+        );
+
+        expect(JSON.parse(mappedData)).toMatchObject([
+            {
+                invalidMessage:
+                    "undefined is an invalid schema, or it may be missing an $id",
+            },
+        ]);
+    });
 });

--- a/packages/design-to-code/src/message-system-service/ajv-validator.service.spec.pw.ts
+++ b/packages/design-to-code/src/message-system-service/ajv-validator.service.spec.pw.ts
@@ -1165,7 +1165,7 @@ test.describe("AjvValidator", () => {
 
         expect(JSON.parse(mappedData)).toMatchObject([
             {
-                invalidMessage: "foo is an invalid schema",
+                invalidMessage: "foo is an invalid schema, or it may be missing an $id",
             },
         ]);
     });


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change throws a warning instead of an error if the `$id` of the JSON schema is missing.

### 🎫 Issues

Resolves #186 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.