### PR TITLE
Add a show validation prop to allow ad-hoc showing validation

### DIFF
--- a/packages/design-to-code-react/app/pages/form.tsx
+++ b/packages/design-to-code-react/app/pages/form.tsx
@@ -70,6 +70,7 @@ export function FormTestPage() {
     const [searchParams, setSearchParams] = useSearchParams();
     const [displayValidationInline, setDisplayValidationInline] = useState(false);
     const [displayValidationErrorList, setDisplayValidationErrorList] = useState(false);
+    const [showValidation, setShowValidation] = useState(false);
 
     const handleMessageSystem = e => {
         switch (e.data?.type) {
@@ -101,6 +102,7 @@ export function FormTestPage() {
 
         const displayValidationInline = searchParams.get("displayValidationInline");
         const displayValidationErrorList = searchParams.get("displayValidationErrorList");
+        const showValidation = searchParams.get("showValidation");
 
         if (displayValidationInline) {
             setDisplayValidationInline(!!displayValidationInline);
@@ -108,6 +110,10 @@ export function FormTestPage() {
 
         if (displayValidationErrorList) {
             setDisplayValidationErrorList(!!displayValidationErrorList);
+        }
+
+        if (showValidation) {
+            setShowValidation(!!showValidation);
         }
     }, [ready]);
 
@@ -134,6 +140,7 @@ export function FormTestPage() {
                 messageSystem={messageSystem}
                 displayValidationInline={displayValidationInline}
                 displayValidationErrorList={displayValidationErrorList}
+                showValidation={showValidation}
             />
             <pre>{JSON.stringify(data, null, 2)}</pre>
         </div>

--- a/packages/design-to-code-react/src/form/controls/format/control.format.date-time.tsx
+++ b/packages/design-to-code-react/src/form/controls/format/control.format.date-time.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { DateTimeControlProps } from "./control.format.date-time.props";
 import { classNames } from "@microsoft/fast-web-utilities";
 import { isDefault } from "../utilities/form";
@@ -35,6 +35,13 @@ function DateTimeControl(props: DateTimeControlProps) {
         };
     }
 
+    useEffect(() => {
+        if (props.validate) {
+            props.updateValidity();
+            props.reportValidity();
+        }
+    }, [props.validate]);
+
     return (
         <span
             className={classNames(
@@ -53,8 +60,8 @@ function DateTimeControl(props: DateTimeControlProps) {
                 onChange={handleChange()}
                 disabled={props.disabled}
                 ref={props.elementRef as React.MutableRefObject<HTMLInputElement>}
-                onBlur={props.updateValidity}
-                onFocus={props.reportValidity}
+                onBlur={() => props.updateValidity()}
+                onFocus={() => props.reportValidity()}
             />
             <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/design-to-code-react/src/form/controls/format/control.format.date.tsx
+++ b/packages/design-to-code-react/src/form/controls/format/control.format.date.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { DateControlProps } from "./control.format.date.props";
 import { classNames } from "@microsoft/fast-web-utilities";
 import { isDefault } from "../utilities/form";
@@ -32,6 +32,13 @@ function DateControl(props: DateControlProps) {
         };
     }
 
+    useEffect(() => {
+        if (props.validate) {
+            props.updateValidity();
+            props.reportValidity();
+        }
+    }, [props.validate]);
+
     return (
         <span
             className={classNames(
@@ -50,8 +57,8 @@ function DateControl(props: DateControlProps) {
                 onChange={handleChange()}
                 disabled={props.disabled}
                 ref={props.elementRef as React.MutableRefObject<HTMLInputElement>}
-                onBlur={props.updateValidity}
-                onFocus={props.reportValidity}
+                onBlur={() => props.updateValidity()}
+                onFocus={() => props.reportValidity()}
             />
             <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/design-to-code-react/src/form/controls/format/control.format.email.tsx
+++ b/packages/design-to-code-react/src/form/controls/format/control.format.email.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { EmailControlProps } from "./control.format.email.props";
 import { classNames } from "@microsoft/fast-web-utilities";
 import { isDefault } from "../utilities/form";
@@ -32,6 +32,13 @@ function EmailControl(props: EmailControlProps) {
         };
     }
 
+    useEffect(() => {
+        if (props.validate) {
+            props.updateValidity();
+            props.reportValidity();
+        }
+    }, [props.validate]);
+
     return (
         <input
             className={classNames(
@@ -47,8 +54,8 @@ function EmailControl(props: EmailControlProps) {
             onChange={handleChange()}
             disabled={props.disabled}
             ref={props.elementRef as React.MutableRefObject<HTMLInputElement>}
-            onBlur={props.updateValidity}
-            onFocus={props.reportValidity}
+            onBlur={() => props.updateValidity()}
+            onFocus={() => props.reportValidity()}
         />
     );
 }

--- a/packages/design-to-code-react/src/form/controls/format/control.format.time.tsx
+++ b/packages/design-to-code-react/src/form/controls/format/control.format.time.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { TimeControlProps } from "./control.format.time.props";
 import { classNames } from "@microsoft/fast-web-utilities";
 import { isDefault } from "../utilities/form";
@@ -35,6 +35,13 @@ function TimeControl(props: TimeControlProps) {
         };
     }
 
+    useEffect(() => {
+        if (props.validate) {
+            props.updateValidity();
+            props.reportValidity();
+        }
+    }, [props.validate]);
+
     return (
         <span
             className={classNames(
@@ -53,8 +60,8 @@ function TimeControl(props: TimeControlProps) {
                 onChange={handleChange()}
                 disabled={props.disabled}
                 ref={props.elementRef as React.MutableRefObject<HTMLInputElement>}
-                onBlur={props.updateValidity}
-                onFocus={props.reportValidity}
+                onBlur={() => props.updateValidity()}
+                onFocus={() => props.reportValidity()}
             />
             {/* !Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc. */}
             <svg

--- a/packages/design-to-code-react/src/form/controls/type/control.button.tsx
+++ b/packages/design-to-code-react/src/form/controls/type/control.button.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { ButtonControlProps } from "./control.button.props";
 import { classNames } from "@microsoft/fast-web-utilities";
 import { isDefault } from "../utilities/form";
@@ -35,6 +35,13 @@ function ButtonControl(props: ButtonControlProps & React.PropsWithChildren) {
      */
     function handleInputChange(): void {}
 
+    useEffect(() => {
+        if (props.validate) {
+            props.updateValidity();
+            props.reportValidity();
+        }
+    }, [props.validate]);
+
     return (
         <React.Fragment>
             <button
@@ -47,8 +54,8 @@ function ButtonControl(props: ButtonControlProps & React.PropsWithChildren) {
                     ]
                 )}
                 ref={props.elementRef as React.Ref<HTMLButtonElement>}
-                onBlur={props.updateValidity}
-                onFocus={props.reportValidity}
+                onBlur={() => props.updateValidity()}
+                onFocus={() => props.reportValidity()}
                 onClick={handleButtonClick()}
                 disabled={props.disabled}
             >

--- a/packages/design-to-code-react/src/form/controls/type/control.checkbox-or-radios.spec.pw.ts
+++ b/packages/design-to-code-react/src/form/controls/type/control.checkbox-or-radios.spec.pw.ts
@@ -6,9 +6,9 @@ test.describe("CheckboxControl", () => {
     }) => {
         await page.goto("/form?schema=controlCheckboxDefault");
 
-        await page.waitForSelector("input");
+        await page.waitForSelector("input[type='checkbox']");
 
-        const checkbox = await page.locator("input");
+        const checkbox = await page.locator("input[type='checkbox']");
 
         await expect(await checkbox.count()).toEqual(1);
 
@@ -37,7 +37,7 @@ test.describe("CheckboxControl", () => {
     }) => {
         await page.goto("/form?schema=controlCheckboxDefault");
 
-        await page.waitForSelector("input");
+        await page.waitForSelector("input[type='checkbox']");
 
         const checkboxContainer = await page.locator(".dtc-checkbox-control");
 
@@ -76,9 +76,9 @@ test.describe("CheckboxControl", () => {
     test("should not show default values if data exists", async ({ page }) => {
         await page.goto("/form?schema=controlCheckboxDefault");
 
-        await page.waitForSelector("input");
+        await page.waitForSelector("input[type='checkbox']");
 
-        const checkbox = await page.locator("input");
+        const checkbox = await page.locator("input[type='checkbox']");
 
         await checkbox.click();
 

--- a/packages/design-to-code-react/src/form/controls/type/control.checkbox-or-radios.style.css
+++ b/packages/design-to-code-react/src/form/controls/type/control.checkbox-or-radios.style.css
@@ -96,6 +96,11 @@
     border-radius: 50%;
     display: grid;
     place-content: center;
+    border: 1px solid transparent;
+}
+
+.dtc-radio-control input:invalid {
+    border-color: var(--dtc-error-color);
 }
 
 .dtc-radio-control input::before {

--- a/packages/design-to-code-react/src/form/controls/type/control.display.tsx
+++ b/packages/design-to-code-react/src/form/controls/type/control.display.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { DisplayControlProps } from "./control.display.props";
 import { classNames } from "@microsoft/fast-web-utilities";
 import { isDefault } from "../utilities/form";
@@ -47,6 +47,13 @@ function DisplayControl(props: DisplayControlProps) {
         }
     }
 
+    useEffect(() => {
+        if (props.validate) {
+            props.updateValidity();
+            props.reportValidity();
+        }
+    }, [props.validate]);
+
     return (
         <input
             className={classNames(
@@ -59,8 +66,8 @@ function DisplayControl(props: DisplayControlProps) {
             )}
             type={"text"}
             ref={props.elementRef as React.Ref<HTMLInputElement>}
-            onBlur={props.updateValidity}
-            onFocus={props.reportValidity}
+            onBlur={() => props.updateValidity()}
+            onFocus={() => props.reportValidity()}
             value={getDisplayValue(props.value)}
             onChange={handleInputChange}
             disabled={props.disabled}

--- a/packages/design-to-code-react/src/form/controls/type/control.number-field.tsx
+++ b/packages/design-to-code-react/src/form/controls/type/control.number-field.tsx
@@ -82,6 +82,13 @@ function NumberFieldControl(props: NumberFieldControlProps) {
         };
     });
 
+    useEffect(() => {
+        if (props.validate) {
+            props.updateValidity();
+            props.reportValidity();
+        }
+    }, [props.validate]);
+
     return (
         <input
             className={classNames(

--- a/packages/design-to-code-react/src/form/controls/type/control.section.tsx
+++ b/packages/design-to-code-react/src/form/controls/type/control.section.tsx
@@ -194,6 +194,7 @@ function SectionControl(props: SectionControlProps) {
                 type={props.type}
                 categories={props.categories}
                 index={index}
+                validate={props.validate}
             />
         );
     }
@@ -385,6 +386,7 @@ function SectionControl(props: SectionControlProps) {
                     strings={props.strings}
                     messageSystemOptions={props.messageSystemOptions}
                     categories={props.categories}
+                    validate={props.validate}
                 />
             );
         }

--- a/packages/design-to-code-react/src/form/controls/type/control.select.tsx
+++ b/packages/design-to-code-react/src/form/controls/type/control.select.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { SelectControlProps } from "./control.select.props";
 import { classNames } from "@microsoft/fast-web-utilities";
 import { isDefault } from "../utilities/form";
@@ -65,6 +65,13 @@ function SelectControl(props: SelectControlProps) {
         });
     }
 
+    useEffect(() => {
+        if (props.validate) {
+            props.updateValidity();
+            props.reportValidity();
+        }
+    }, [props.validate]);
+
     return (
         <span
             className={classNames(
@@ -82,8 +89,8 @@ function SelectControl(props: SelectControlProps) {
                 value={getValue()}
                 disabled={props.disabled}
                 ref={props.elementRef as React.Ref<HTMLSelectElement>}
-                onBlur={props.updateValidity}
-                onFocus={props.reportValidity}
+                onBlur={() => props.updateValidity()}
+                onFocus={() => props.reportValidity()}
             >
                 {renderOptions()}
             </select>

--- a/packages/design-to-code-react/src/form/controls/type/control.textarea.tsx
+++ b/packages/design-to-code-react/src/form/controls/type/control.textarea.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { TextareaControlProps } from "./control.textarea.props";
 import { classNames } from "@microsoft/fast-web-utilities";
 import { isDefault } from "../utilities/form";
@@ -50,6 +50,13 @@ function TextareaControl(props: TextareaControlProps) {
             props.onChange({ value: e.target.value });
         };
     }
+
+    useEffect(() => {
+        if (props.validate) {
+            props.updateValidity();
+            props.reportValidity();
+        }
+    }, [props.validate]);
 
     return (
         <textarea

--- a/packages/design-to-code-react/src/form/controls/type/control.untyped.tsx
+++ b/packages/design-to-code-react/src/form/controls/type/control.untyped.tsx
@@ -21,6 +21,13 @@ function UntypedControl(props: UntypedControlProps) {
         setDetectedType(getType());
     }, [props.value]);
 
+    useEffect(() => {
+        if (props.validate) {
+            props.updateValidity();
+            props.reportValidity();
+        }
+    }, [props.validate]);
+
     function getType(): DataType {
         const typeofValue = typeof props.value;
         return Array.isArray(props.value)

--- a/packages/design-to-code-react/src/form/controls/utilities/control-switch.tsx
+++ b/packages/design-to-code-react/src/form/controls/utilities/control-switch.tsx
@@ -357,6 +357,7 @@ function ControlSwitch(props: ControlSwitchProps) {
             strings: props.strings,
             messageSystemOptions: props.messageSystemOptions,
             categories: props.categories,
+            validate: props.validate,
         };
     }
 

--- a/packages/design-to-code-react/src/form/controls/utilities/dictionary.tsx
+++ b/packages/design-to-code-react/src/form/controls/utilities/dictionary.tsx
@@ -160,6 +160,7 @@ function Dictionary(props: DictionaryProps) {
                                     schemaDictionary={props.schemaDictionary}
                                     messageSystem={props.messageSystem}
                                     messageSystemOptions={props.messageSystemOptions}
+                                    validate={props.validate}
                                 />
                             </div>
                         </React.Fragment>

--- a/packages/design-to-code-react/src/form/form.props.ts
+++ b/packages/design-to-code-react/src/form/form.props.ts
@@ -100,6 +100,11 @@ export interface FormProps {
      * Category configurations
      */
     categories?: FormCategoryDictionary;
+
+    /**
+     * Show validation against all visible controls
+     */
+    showValidation?: boolean;
 }
 
 /**

--- a/packages/design-to-code-react/src/form/form.tsx
+++ b/packages/design-to-code-react/src/form/form.tsx
@@ -19,7 +19,6 @@ import {
     BareControlPlugin,
     ControlConfig,
     ControlType,
-    SingleLineControlPlugin,
     StandardControlPlugin,
 } from "./templates";
 import { ControlContext, LinkedDataActionType, OnChangeConfig } from "./templates/types";
@@ -485,6 +484,7 @@ const Form: React.FC<FormProps> = (
             strings: strings,
             messageSystemOptions: options,
             categories: props.categories || {},
+            validate: props.showValidation,
         });
 
         return control.render();

--- a/packages/design-to-code-react/src/form/templates/template.control.utilities.props.tsx
+++ b/packages/design-to-code-react/src/form/templates/template.control.utilities.props.tsx
@@ -200,6 +200,11 @@ export interface ControlTemplateUtilitiesProps
      * Localized strings for default controls.
      */
     strings: FormStrings;
+
+    /**
+     * Validate the component
+     */
+    validate: boolean;
 }
 
 export interface CommonControlConfig {
@@ -264,6 +269,11 @@ export interface CommonControlConfig {
     validationErrors: ValidationError[];
 
     /**
+     * The invalid message
+     */
+    invalidMessage: string;
+
+    /**
      * Display the validation inline
      */
     displayValidationInline?: boolean;
@@ -284,7 +294,7 @@ export interface CommonControlConfig {
      * Callback for updating validity on
      * the element that is assigned the ref
      */
-    updateValidity: () => void;
+    updateValidity: (refs?: React.RefObject<HTMLElement>[]) => void;
 
     /**
      * Callback for handling the updating of the value
@@ -305,6 +315,11 @@ export interface CommonControlConfig {
      * Localized strings for default controls.
      */
     strings: FormStrings;
+
+    /**
+     * Validate controls
+     */
+    validate: boolean;
 }
 
 export interface NumberFieldTypeControlOptions {

--- a/packages/design-to-code-react/src/form/templates/template.control.utilities.tsx
+++ b/packages/design-to-code-react/src/form/templates/template.control.utilities.tsx
@@ -244,12 +244,20 @@ export interface UpdateValidityProps {
  *    updateValidity();
  * });
  */
-export function updateValidity(props: UpdateValidityProps): () => void {
-    return function (): void {
+export function updateValidity(
+    props: UpdateValidityProps
+): (refs?: React.RefObject<HTMLInputElement>[]) => void {
+    return function (refs?: React.RefObject<HTMLInputElement>[]): void {
         const formControlElement: HTMLElement = props.ref.current;
 
         if (formControlElement !== null && typeof formControlElement !== "undefined") {
             props.ref.current.setCustomValidity(props.invalidMessage);
+        }
+
+        if (Array.isArray(refs)) {
+            refs.forEach(ref => {
+                ref.current.setCustomValidity(props.invalidMessage);
+            });
         }
     };
 }
@@ -334,6 +342,7 @@ export function getConfig(props: GetConfigProps): ControlConfig {
         strings: props.strings,
         messageSystemOptions: props.messageSystemOptions,
         categories: props.categories,
+        validate: props.validate,
     };
 }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This allows a `showValidation` prop to be set on the form. This can be used by triggering an external submit button and setting this to `true`, which will show highlighted validation states on form controls.

### 🎫 Issues

Closes #165

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.