### PR TITLE
Update packages to 1.0.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "copyfiles": "^2.4.1",
     "css-loader": "^6.7.3",
-    "design-to-code-react": "^1.0.0-alpha.15",
+    "design-to-code-react": "^1.0.0",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",
     "lodash-es": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "copy-webpack-plugin": "^11.0.0",
         "copyfiles": "^2.4.1",
         "css-loader": "^6.7.3",
-        "design-to-code-react": "^1.0.0-alpha.15",
+        "design-to-code-react": "^1.0.0",
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.5.0",
         "lodash-es": "^4.17.21",
@@ -12396,7 +12396,7 @@
       }
     },
     "packages/design-to-code": {
-      "version": "1.0.0-alpha.15",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@microsoft/fast-colors": "^5.3.1",
@@ -12440,14 +12440,14 @@
       }
     },
     "packages/design-to-code-react": {
-      "version": "1.0.0-alpha.15",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@microsoft/fast-element": "^1.5.1",
         "@microsoft/fast-foundation": "^2.13.1",
         "@microsoft/fast-web-utilities": "^4.8.1",
         "@skatejs/val": "^0.5.0",
-        "design-to-code": "^1.0.0-alpha.15",
+        "design-to-code": "^1.0.0",
         "exenv-es6": "^1.0.0",
         "raf-throttle": "^2.0.3",
         "react-dnd": "^16.0.0"
@@ -14985,7 +14985,7 @@
         "copy-webpack-plugin": "^11.0.0",
         "copyfiles": "^2.4.1",
         "css-loader": "^6.7.3",
-        "design-to-code-react": "^1.0.0-alpha.15",
+        "design-to-code-react": "^1.0.0",
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.5.0",
         "lodash-es": "^4.17.21",
@@ -16261,7 +16261,7 @@
         "@types/react": "^18.0.0",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.7.3",
-        "design-to-code": "^1.0.0-alpha.15",
+        "design-to-code": "^1.0.0",
         "eslint-config-prettier": "^6.10.1",
         "eslint-plugin-react": "^7.19.0",
         "exenv-es6": "^1.0.0",

--- a/packages/design-to-code-react/package.json
+++ b/packages/design-to-code-react/package.json
@@ -2,7 +2,7 @@
   "name": "design-to-code-react",
   "description": "A React-specific set of components and utilities to assist in creating web UI",
   "sideEffects": false,
-  "version": "1.0.0-alpha.15",
+  "version": "1.0.0",
   "author": "Jane Chu",
   "license": "MIT",
   "repository": {
@@ -72,7 +72,7 @@
     "@microsoft/fast-foundation": "^2.13.1",
     "@microsoft/fast-web-utilities": "^4.8.1",
     "@skatejs/val": "^0.5.0",
-    "design-to-code": "^1.0.0-alpha.15",
+    "design-to-code": "^1.0.0",
     "exenv-es6": "^1.0.0",
     "raf-throttle": "^2.0.3",
     "react-dnd": "^16.0.0"

--- a/packages/design-to-code/package.json
+++ b/packages/design-to-code/package.json
@@ -2,7 +2,7 @@
   "name": "design-to-code",
   "description": "A set of utilities to assist in creating web UI",
   "sideEffects": false,
-  "version": "1.0.0-alpha.15",
+  "version": "1.0.0",
   "type": "module",
   "author": "Jane Chu",
   "license": "MIT",


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
There are no further breaking changes in the `design-to-code` or `design-to-code-react` packages, as such they are now being bumped to `1.0.0` as initial release.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Testing the beachball setup for automated package bumps
- Adding in GitHub action for automated package bumps