### PR TITLE
Add missing 'run' from a workflow npm script

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -52,7 +52,7 @@ jobs:
       run: npm run build --workspace=design-to-code --workspace=design-to-code-react
 
     - name: Check for the presence of changed files inside ./change
-      run: npm check
+      run: npm run check
 
     - name: Testing diffs
       run: npm run test:diff


### PR DESCRIPTION
# Pull Request

## 📖 Description

This adds a missing 'run' from an attempt to run an npm script run on a workflow.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.