### PR TITLE
Explicitly pass the GitHub default token to override permissions

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -71,6 +71,7 @@ jobs:
       uses: romeovs/lcov-reporter-action@v0.3.1
       with:
         lcov-file: ./packages/design-to-code/coverage/lcov.info
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Test design to code react package
       run: npm run test --workspace=design-to-code-react
@@ -82,6 +83,7 @@ jobs:
       uses: romeovs/lcov-reporter-action@v0.3.1
       with:
         lcov-file: ./packages/design-to-code-react/coverage/lcov.info
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build docs site
       run: npm run build:gh-pages


### PR DESCRIPTION
# Pull Request

## 📖 Description

Explicitly pass the GitHub default token to overcome a forked repos PR from running into an issue in the validation workflow.