### PR TITLE
Remove custom PAT in workflow

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -12,7 +12,9 @@ on:
       - gh-pages
       - 'features/**'
 
-permissions: write-all
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   build:
@@ -71,7 +73,7 @@ jobs:
       uses: romeovs/lcov-reporter-action@v0.3.1
       with:
         lcov-file: ./packages/design-to-code/coverage/lcov.info
-        github-token: ${{ secrets.CI_PAT }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Test design to code react package
       run: npm run test --workspace=design-to-code-react
@@ -83,7 +85,7 @@ jobs:
       uses: romeovs/lcov-reporter-action@v0.3.1
       with:
         lcov-file: ./packages/design-to-code-react/coverage/lcov.info
-        github-token: ${{ secrets.CI_PAT }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build docs site
       run: npm run build:gh-pages


### PR DESCRIPTION
# Pull Request

## 📖 Description

The custom PAT was not working with the lcov reporter github action, removing it to see if setting workflow permissions will suffice.