### PR TITLE
Sets the publish to automatically dispatch at 6am on Mondays

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -1,6 +1,8 @@
 name: Release NPM Packages
 
 on:
+  schedule:
+    - cron: 0 6 * * 1
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
# Pull Request

## 📖 Description

This sets the cron job to automatically run on Mondays at 6am, [crontab guru](https://crontab.guru/#0_6_*_*_1) was used to generate the time.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.