### PR TITLE
Add a secret action for GH token to specify workflow permissions

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
   GITHUB_SERVICE_USER: "Jane Chu"
   GITHUB_SERVICE_EMAIL: "7559015+janechu@users.noreply.github.com"
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Insufficient permissions to on the publish workflow which causes the following failure:
```
remote: error: GH006: Protected branch update failed for refs/heads/main. 
```
