### PR TITLE
Fix `undefined` showing as `false` for radios

### DIFF
--- a/change/design-to-code-react-5e266eef-3365-48de-9b79-e25af272992e.json
+++ b/change/design-to-code-react-5e266eef-3365-48de-9b79-e25af272992e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixes an issue where undefined would show as false for radios",
+  "packageName": "design-to-code-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/design-to-code-react/app/pages/form.tsx
+++ b/packages/design-to-code-react/app/pages/form.tsx
@@ -95,14 +95,20 @@ export function FormTestPage() {
 
     useEffect(() => {
         // run when ready (second load)
-        initializeMessageSystem(
-            searchParams.get("schema"),
-            getExampleData(searchParams.get("schema"))
-        );
 
+        /**
+         * To use search params, add to the URL:
+         * &<search-param>=true
+         */
         const displayValidationInline = searchParams.get("displayValidationInline");
         const displayValidationErrorList = searchParams.get("displayValidationErrorList");
         const showValidation = searchParams.get("showValidation");
+        const dataIsUndefined = searchParams.get("dataIsUndefined");
+
+        initializeMessageSystem(
+            searchParams.get("schema"),
+            dataIsUndefined ? undefined : getExampleData(searchParams.get("schema"))
+        );
 
         if (displayValidationInline) {
             setDisplayValidationInline(!!displayValidationInline);

--- a/packages/design-to-code-react/src/form/controls/type/control.checkbox-or-radios.spec.pw.ts
+++ b/packages/design-to-code-react/src/form/controls/type/control.checkbox-or-radios.spec.pw.ts
@@ -78,12 +78,14 @@ test.describe("CheckboxControl", () => {
     }) => {
         await page.goto("/form?schema=controlCheckbox&dataIsUndefined=true");
 
+        await page.waitForSelector("input");
+
         const radios = await page.locator("input[type='radio']");
 
         await expect(await radios.count()).toEqual(2);
 
-        await expect(radios.nth(0).inputValue()).toEqual(false);
-        await expect(radios.nth(1).inputValue()).toEqual(false);
+        await expect(await radios.nth(0).isChecked()).toEqual(false);
+        await expect(await radios.nth(1).isChecked()).toEqual(false);
     });
     test("should not show default values if data exists", async ({ page }) => {
         await page.goto("/form?schema=controlCheckboxDefault");

--- a/packages/design-to-code-react/src/form/controls/type/control.checkbox-or-radios.spec.pw.ts
+++ b/packages/design-to-code-react/src/form/controls/type/control.checkbox-or-radios.spec.pw.ts
@@ -73,6 +73,18 @@ test.describe("CheckboxControl", () => {
 
         await expect(await checkbox.inputValue()).toEqual("true");
     });
+    test("should not show any checked values if no data is available", async ({
+        page,
+    }) => {
+        await page.goto("/form?schema=controlCheckbox&dataIsUndefined=true");
+
+        const radios = await page.locator("input[type='radio']");
+
+        await expect(await radios.count()).toEqual(2);
+
+        await expect(radios.nth(0).inputValue()).toEqual(false);
+        await expect(radios.nth(1).inputValue()).toEqual(false);
+    });
     test("should not show default values if data exists", async ({ page }) => {
         await page.goto("/form?schema=controlCheckboxDefault");
 

--- a/packages/design-to-code-react/src/form/controls/type/control.checkbox-or-radios.tsx
+++ b/packages/design-to-code-react/src/form/controls/type/control.checkbox-or-radios.tsx
@@ -18,12 +18,12 @@ const falseRadioId = `dtc-${uniqueId()}`;
  */
 function CheckboxOrRadiosControl(props: CheckboxControlProps) {
     const containsDefault: boolean = typeof props.default === "boolean";
-    const value: boolean =
+    const value: boolean | void =
         typeof props.value === "boolean"
             ? props.value
             : typeof props.value === "undefined" && containsDefault
             ? props.default
-            : false;
+            : undefined;
     const radioTrueRef = useRef(null);
     const radioFalseRef = useRef(null);
 
@@ -59,6 +59,16 @@ function CheckboxOrRadiosControl(props: CheckboxControlProps) {
         }
     }, [props.value]);
 
+    function getCheckedValue(value: boolean | void): "true" | "false" | "undefined" {
+        return isBoolean(value)
+            ? ((value as boolean).toString() as "true" | "false")
+            : "undefined";
+    }
+
+    function isBoolean(value: boolean | void): boolean {
+        return value === true || value === false;
+    }
+
     function renderCheckbox() {
         return (
             <div
@@ -75,9 +85,9 @@ function CheckboxOrRadiosControl(props: CheckboxControlProps) {
                     className={"dtc-checkbox-control_input"}
                     id={props.dataLocation}
                     type={"checkbox"}
-                    value={value.toString()}
+                    value={getCheckedValue(value)}
                     onChange={handleChange()}
-                    checked={value}
+                    checked={value || false}
                     disabled={props.disabled}
                     ref={props.elementRef as React.Ref<HTMLInputElement>}
                     onFocus={() => props.reportValidity()}
@@ -105,7 +115,7 @@ function CheckboxOrRadiosControl(props: CheckboxControlProps) {
                         name={props.dataLocation}
                         value={"true"}
                         onChange={handleChange()}
-                        checked={value.toString() === "true"}
+                        checked={getCheckedValue(value) === "true"}
                         ref={radioTrueRef}
                         onFocus={() => props.reportValidity()}
                         onBlur={updateRadioValidity}
@@ -124,7 +134,7 @@ function CheckboxOrRadiosControl(props: CheckboxControlProps) {
                         checked={
                             props.invalidMessage !== ""
                                 ? false
-                                : value.toString() === "false"
+                                : getCheckedValue(value) === "false"
                         }
                         ref={radioFalseRef}
                         onFocus={() => props.reportValidity()}


### PR DESCRIPTION
# Pull Request

## 📖 Description

Radios will show `false` instead of no radio being selected when the value is undefined. This change fixes it so that they are not checked if the value is `undefined`.

### 🎫 Issues

Closes #229

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.