### PR TITLE
Fix an issue on windows with glob patterns not working for the copy webpack plugin

### DIFF
--- a/packages/design-to-code-react/webpack.config.cjs
+++ b/packages/design-to-code-react/webpack.config.cjs
@@ -64,7 +64,10 @@ module.exports = {
         new CopyWebpackPlugin({
             patterns: [
                 {
-                    from: path.resolve("../design-to-code/dist/stylesheets/**/*.css"),
+                    from: path.posix.join(
+                        path.resolve(__dirname, "../design-to-code/dist/stylesheets/**").replace(/\\/g, "/"),
+                        "*.css"
+                    ),
                     to: "public/[name][ext]"
                 },
             ],


### PR DESCRIPTION
# Pull Request

## 📖 Description

Windows pathing issue resolved using [Copy Webpack Plugin documentation](https://webpack.js.org/plugins/copy-webpack-plugin/#for-windows).
